### PR TITLE
Fix iOS push tracking — handlePushOpen/handleForegroundPush were silent no-ops

### DIFF
--- a/Bonni/ios/Bonni/AppDelegate.swift
+++ b/Bonni/ios/Bonni/AppDelegate.swift
@@ -79,43 +79,19 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
   /**
    * Handle notification tap/interaction.
    *
-   * Calls the Attentive SDK via `AttentiveSDKManager.shared` using the full
-   * `UNNotificationResponse` (required by the native iOS SDK) so that push open /
-   * foreground push events are tracked correctly. The response is also forwarded to
-   * `RNCPushNotificationIOS` so the React Native JS layer receives the corresponding
-   * `localNotification` event for any additional in-app UI handling.
-   *
-   * Note: the `handleForegroundPush` / `handlePushOpen` paths that go through the
-   * RN bridge (`src/index.tsx`) are no-ops on iOS because the native SDK requires a
-   * `UNNotificationResponse` object which cannot be marshalled across the RN bridge.
-   * This AppDelegate method is the authoritative push-tracking entry point on iOS.
+   * `handleNotificationResponse` automatically detects the app state, fetches
+   * the authorization status, and calls the correct native SDK method
+   * (`handlePushOpen` or `handleForegroundPush`).  It also caches the response
+   * so the RN bridge can fulfil any JS-side `handlePushOpen()` /
+   * `handleForegroundPush()` calls without double-tracking.
    */
   func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
     print("[Attentive] Notification tapped/received response")
 
-    // Fetch the current auth status asynchronously then dispatch to the Attentive SDK
-    // on the main thread, mirroring the recommended native AppDelegate pattern.
-    UNUserNotificationCenter.current().getNotificationSettings { settings in
-      let authStatus = settings.authorizationStatus
-      DispatchQueue.main.async {
-        switch UIApplication.shared.applicationState {
-        case .active:
-          // App was in the foreground when the user interacted with the notification.
-          AttentiveSDKManager.shared.handleForegroundPush(response: response, authorizationStatus: authStatus)
-          print("[Attentive] handleForegroundPush called via AttentiveSDKManager (app was active)")
-        case .background, .inactive:
-          // App was backgrounded or in the middle of transitioning.
-          AttentiveSDKManager.shared.handlePushOpen(response: response, authorizationStatus: authStatus)
-          print("[Attentive] handlePushOpen called via AttentiveSDKManager (app was background/inactive)")
-        @unknown default:
-          AttentiveSDKManager.shared.handlePushOpen(response: response, authorizationStatus: authStatus)
-          print("[Attentive] handlePushOpen called via AttentiveSDKManager (unknown app state)")
-        }
-      }
-    }
+    // One-line Attentive push tracking (handles app-state + auth status internally)
+    AttentiveSDKManager.shared.handleNotificationResponse(response)
 
-    // Also forward to React Native so the JS `localNotification` event fires
-    // and any in-app UI logic (navigation, banners, etc.) can respond.
+    // Forward to React Native so the JS `localNotification` event fires
     RNCPushNotificationIOS.didReceive(response)
 
     completionHandler()

--- a/Bonni/ios/Bonni/AppDelegate.swift
+++ b/Bonni/ios/Bonni/AppDelegate.swift
@@ -3,6 +3,7 @@ import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
 import UserNotifications
+import attentive_react_native_sdk
 
 @main
 class AppDelegate: RCTAppDelegate {

--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ Attentive.identify({phone: '+15556667777'};)
 
 The SDK supports push notification integration on both iOS (APNs) and Android (runtime permission + optional FCM). The following sections cover iOS-specific flows and a full **App events on Android** implementation that mirrors the behavior of the [Bonni](https://github.com/attentive-mobile/attentive-react-native-sdk/tree/main/Bonni) example app.
 
+> **iOS — required setup:** Your AppDelegate **must** forward notification
+> responses to the SDK for push tracking to work. Add this single line to your
+> `userNotificationCenter(_:didReceive:withCompletionHandler:)`:
+>
+> ```swift
+> AttentiveSDKManager.shared.handleNotificationResponse(response)
+> ```
+>
+> Without this, push open and foreground push events **will not be tracked** on
+> iOS. See [iOS AppDelegate Integration](#ios-appdelegate-integration) for full
+> details.
+
 ---
 
 ### App Events on Android
@@ -373,7 +385,40 @@ For proper push notification integration, your iOS AppDelegate needs to:
 
 1. Request notification permissions via the SDK
 2. Implement `application:didRegisterForRemoteNotificationsWithDeviceToken:` to register the token
-3. Implement `UNUserNotificationCenterDelegate` methods to handle notification events
+3. **Forward notification responses to the SDK for push-open tracking**
+
+##### Push Open Tracking (Required)
+
+Add **one line** to your AppDelegate's `didReceive` handler so the SDK can track
+push opens and foreground push events. Without this, `handlePushOpen()` and
+`handleForegroundPush()` called from JavaScript will not be able to track events
+on iOS (the native SDK requires a `UNNotificationResponse` which cannot cross the
+React Native bridge).
+
+```swift
+// In AppDelegate.swift — UNUserNotificationCenterDelegate
+func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse,
+    withCompletionHandler completionHandler: @escaping () -> Void
+) {
+    // Attentive push tracking (handles app-state + auth status automatically)
+    AttentiveSDKManager.shared.handleNotificationResponse(response)
+
+    // Forward to your push library (e.g. RNCPushNotificationIOS) for JS events
+    RNCPushNotificationIOS.didReceive(response)
+    completionHandler()
+}
+```
+
+`handleNotificationResponse` automatically:
+- Detects whether the app is in the foreground or background
+- Fetches the current authorization status
+- Calls the correct native SDK method (`handlePushOpen` or `handleForegroundPush`)
+- Caches the response so the JS-side `handlePushOpen()` / `handleForegroundPush()` calls
+  are fulfilled without double-tracking
+- **Cold-launch safe:** If the user taps a push while the app is killed, the
+  response is cached and automatically tracked once the SDK initializes
 
 ##### Callback-Based Registration (Recommended)
 
@@ -390,13 +435,13 @@ func application(
 ) {
     UNUserNotificationCenter.current().getNotificationSettings { settings in
         let authStatus = settings.authorizationStatus
-        
+
         // Get SDK instance with proper type
         guard let attentiveSdk = AttentiveSDKManager.shared.sdk as? ATTNNativeSDK else {
             print("[Attentive] SDK not initialized")
             return
         }
-        
+
         // Register device token with callback
         attentiveSdk.registerDeviceToken(
             deviceToken,
@@ -407,7 +452,7 @@ func application(
                     if let error = error {
                         print("[Attentive] Registration failed: \(error.localizedDescription)")
                     }
-                    
+
                     // Trigger regular open event after registration
                     attentiveSdk.handleRegularOpen(authorizationStatus: authStatus)
                 }

--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ The SDK supports push notification integration on both iOS (APNs) and Android (r
 > Without this, push open and foreground push events **will not be tracked** on
 > iOS. See [iOS AppDelegate Integration](#ios-appdelegate-integration) for full
 > details.
+>
+> **Migrating from an earlier version?** If you previously called
+> `AttentiveSDKManager.shared.handleForegroundPush(response:authorizationStatus:)`
+> or `AttentiveSDKManager.shared.handlePushOpen(response:authorizationStatus:)`
+> directly from your AppDelegate, **replace** that code with the single
+> `handleNotificationResponse` call above. Using both will result in
+> double-tracked events. The old methods are now deprecated.
 
 ---
 

--- a/ios/Bridging/ATTNNativeSDK.swift
+++ b/ios/Bridging/ATTNNativeSDK.swift
@@ -383,63 +383,126 @@ struct DebugEvent {
   /**
    * React Native bridge entry point for foreground push tracking.
    *
-   * **Important — iOS limitation**: The Attentive iOS SDK requires a `UNNotificationResponse`
-   * object for `handleForegroundPush`, which is an opaque system type that cannot be
-   * serialised across the React Native bridge. Calling this method from JS therefore
-   * **cannot invoke the native SDK** and is a no-op.
+   * The Attentive iOS SDK requires a `UNNotificationResponse` which cannot be
+   * serialised across the React Native bridge. To work around this, the method
+   * checks `AttentiveSDKManager.shared` for a cached response (set by the
+   * recommended `handleNotificationResponse(_:)` call in AppDelegate).
    *
-   * The correct solution for iOS is to call
-   * `AttentiveSDKManager.shared.handleForegroundPush(response:authorizationStatus:)`
-   * directly from the host app's `UNUserNotificationCenterDelegate` implementation
-   * (i.e. `AppDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)`).
-   * Bonni's `AppDelegate.swift` already does this, so foreground push events are tracked
-   * correctly via the native path — this RN bridge variant is intentionally unused on iOS.
+   * - If a cached response exists **and was already tracked**, this is a no-op
+   *   (prevents double-tracking).
+   * - If a cached response exists **but was not yet tracked**, it is used to
+   *   call the real native SDK method.
+   * - If no cached response is available, a warning is logged instructing the
+   *   developer to add `AttentiveSDKManager.shared.handleNotificationResponse(response)`
+   *   to their AppDelegate.
    *
-   * @param userInfo The notification payload dictionary (unused on iOS).
-   * @param authorizationStatus Current push authorization status string (unused on iOS).
+   * @param userInfo The notification payload dictionary.
+   * @param authorizationStatus Current push authorization status string.
    */
   @objc(handleForegroundPushFromRN:authorizationStatus:)
   public func handleForegroundPushFromRN(_ userInfo: [String: Any], authorizationStatus: String) {
-    // iOS: no-op — tracking is performed natively via AttentiveSDKManager in AppDelegate.
-    // The UNNotificationResponse required by the iOS SDK cannot cross the RN bridge.
-    print("[AttentiveSDK] handleForegroundPushFromRN: iOS push tracking is handled natively via AttentiveSDKManager in AppDelegate. This RN bridge call is a no-op on iOS.")
+    if let pending = AttentiveSDKManager.shared.consumePendingResponse() {
+      if pending.alreadyTracked {
+        // Already tracked by handleNotificationResponse — nothing to do.
+        if debuggingEnabled {
+          showDebugInfo(event: "Foreground Push (already tracked natively)", data: [
+            "authorizationStatus": authorizationStatus,
+            "note": "Push was already tracked via AttentiveSDKManager.handleNotificationResponse."
+          ])
+        }
+        return
+      }
 
-    if debuggingEnabled {
-      showDebugInfo(event: "Foreground Push (RN bridge — iOS no-op)", data: [
-        "authorizationStatus": authorizationStatus,
-        "userInfo": userInfo,
-        "note": "iOS: tracked via AppDelegate → AttentiveSDKManager. UNNotificationResponse not available from RN bridge."
-      ])
+      // Cached response exists but wasn't tracked yet — track it now.
+      let authStatus = mapAuthorizationStatus(authorizationStatus)
+      sdk.handleForegroundPush(response: pending.response, authorizationStatus: authStatus)
+
+      if debuggingEnabled {
+        let cachedUserInfo = pending.response.notification.request.content.userInfo
+        showDebugInfo(event: "Foreground Push (tracked via cached response)", data: [
+          "authorizationStatus": authorizationStatus,
+          "userInfo": cachedUserInfo as? [String: Any] ?? [:],
+          "actionIdentifier": pending.response.actionIdentifier
+        ])
+      }
+    } else {
+      // No cached response. Either:
+      //   (a) The client's AppDelegate is missing handleNotificationResponse, or
+      //   (b) A prior bridge call (handlePushOpen / handleForegroundPush) already consumed it.
+      print("[AttentiveSDK] handleForegroundPushFromRN: No cached UNNotificationResponse available.")
+      print("[AttentiveSDK] If push tracking is not working, add this line to your AppDelegate's didReceive handler:")
+      print("[AttentiveSDK]   AttentiveSDKManager.shared.handleNotificationResponse(response)")
+
+      if debuggingEnabled {
+        showDebugInfo(event: "Foreground Push (no cached response)", data: [
+          "authorizationStatus": authorizationStatus,
+          "userInfo": userInfo,
+          "note": "No cached response — either already consumed by a prior call or AppDelegate setup missing."
+        ])
+      }
     }
   }
 
   /**
    * React Native bridge entry point for push-open tracking (background/inactive tap).
    *
-   * **Important — iOS limitation**: The Attentive iOS SDK requires a `UNNotificationResponse`
-   * object for `handlePushOpen`, which cannot be serialised across the React Native bridge.
-   * Calling this method from JS is therefore a **no-op on iOS**.
+   * The Attentive iOS SDK requires a `UNNotificationResponse` which cannot be
+   * serialised across the React Native bridge. To work around this, the method
+   * checks `AttentiveSDKManager.shared` for a cached response (set by the
+   * recommended `handleNotificationResponse(_:)` call in AppDelegate).
    *
-   * The correct solution is to call
-   * `AttentiveSDKManager.shared.handlePushOpen(response:authorizationStatus:)` directly
-   * from `AppDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)`.
-   * Bonni's `AppDelegate.swift` already does this via the native path.
+   * - If a cached response exists **and was already tracked**, this is a no-op
+   *   (prevents double-tracking).
+   * - If a cached response exists **but was not yet tracked**, it is used to
+   *   call the real native SDK method.
+   * - If no cached response is available, a warning is logged instructing the
+   *   developer to add `AttentiveSDKManager.shared.handleNotificationResponse(response)`
+   *   to their AppDelegate.
    *
-   * @param userInfo The notification payload dictionary (unused on iOS).
-   * @param authorizationStatus Current push authorization status string (unused on iOS).
+   * @param userInfo The notification payload dictionary.
+   * @param authorizationStatus Current push authorization status string.
    */
   @objc(handlePushOpenFromRN:authorizationStatus:)
   public func handlePushOpenFromRN(_ userInfo: [String: Any], authorizationStatus: String) {
-    // iOS: no-op — tracking is performed natively via AttentiveSDKManager in AppDelegate.
-    // The UNNotificationResponse required by the iOS SDK cannot cross the RN bridge.
-    print("[AttentiveSDK] handlePushOpenFromRN: iOS push tracking is handled natively via AttentiveSDKManager in AppDelegate. This RN bridge call is a no-op on iOS.")
+    if let pending = AttentiveSDKManager.shared.consumePendingResponse() {
+      if pending.alreadyTracked {
+        // Already tracked by handleNotificationResponse — nothing to do.
+        if debuggingEnabled {
+          showDebugInfo(event: "Push Open (already tracked natively)", data: [
+            "authorizationStatus": authorizationStatus,
+            "note": "Push was already tracked via AttentiveSDKManager.handleNotificationResponse."
+          ])
+        }
+        return
+      }
 
-    if debuggingEnabled {
-      showDebugInfo(event: "Push Open (RN bridge — iOS no-op)", data: [
-        "authorizationStatus": authorizationStatus,
-        "userInfo": userInfo,
-        "note": "iOS: tracked via AppDelegate → AttentiveSDKManager. UNNotificationResponse not available from RN bridge."
-      ])
+      // Cached response exists but wasn't tracked yet — track it now.
+      let authStatus = mapAuthorizationStatus(authorizationStatus)
+      sdk.handlePushOpen(response: pending.response, authorizationStatus: authStatus)
+
+      if debuggingEnabled {
+        let cachedUserInfo = pending.response.notification.request.content.userInfo
+        showDebugInfo(event: "Push Open (tracked via cached response)", data: [
+          "authorizationStatus": authorizationStatus,
+          "userInfo": cachedUserInfo as? [String: Any] ?? [:],
+          "actionIdentifier": pending.response.actionIdentifier
+        ])
+      }
+    } else {
+      // No cached response. Either:
+      //   (a) The client's AppDelegate is missing handleNotificationResponse, or
+      //   (b) A prior bridge call (handlePushOpen / handleForegroundPush) already consumed it.
+      print("[AttentiveSDK] handlePushOpenFromRN: No cached UNNotificationResponse available.")
+      print("[AttentiveSDK] If push tracking is not working, add this line to your AppDelegate's didReceive handler:")
+      print("[AttentiveSDK]   AttentiveSDKManager.shared.handleNotificationResponse(response)")
+
+      if debuggingEnabled {
+        showDebugInfo(event: "Push Open (no cached response)", data: [
+          "authorizationStatus": authorizationStatus,
+          "userInfo": userInfo,
+          "note": "No cached response — either already consumed by a prior call or AppDelegate setup missing."
+        ])
+      }
     }
   }
 

--- a/ios/Bridging/AttentiveSDKManager.swift
+++ b/ios/Bridging/AttentiveSDKManager.swift
@@ -57,6 +57,12 @@ import UserNotifications
     /// Prevents double-tracking when both the native convenience method and the JS bridge fire.
     private var pendingResponseTracked: Bool = false
 
+    /// The app state captured at the moment `handleNotificationResponse` was called.
+    /// Stored so that cold-launch replays use the original state (typically `.inactive`
+    /// or `.background`) rather than `.active` which is what the app will be in by the
+    /// time the SDK finishes initializing.
+    private var pendingAppState: UIApplication.State = .inactive
+
     /// Serialises access to the cache fields above.
     private let responseLock = NSLock()
 
@@ -100,15 +106,22 @@ import UserNotifications
      * @param response The `UNNotificationResponse` from the notification center delegate.
      */
     @objc public func handleNotificationResponse(_ response: UNNotificationResponse) {
+        // Capture app state NOW — by the time the async block or cold-launch
+        // replay runs, the app will likely be .active regardless of how it was
+        // actually launched. Storing the state ensures a killed-state push tap
+        // is correctly classified as a push open, not a foreground push.
+        let appState = UIApplication.shared.applicationState
+
         // Cache the response for the RN bridge (consumed by handlePushOpenFromRN / handleForegroundPushFromRN).
         // pendingResponseTracked stays false until tracking actually executes, so a bridge
         // call that races with the async block below will still track correctly.
         responseLock.lock()
         pendingResponse = response
         pendingResponseTracked = false
+        pendingAppState = appState
         responseLock.unlock()
 
-        trackResponse(response)
+        trackResponse(response, appState: appState)
     }
 
     // MARK: - Push Notification Handlers (for AppDelegate)
@@ -164,11 +177,25 @@ import UserNotifications
     /// Attempt to track a cached response via the native SDK.
     /// If nativeSDK is nil (cold launch), returns without marking tracked;
     /// the `sdk` didSet will call `flushPendingResponseIfNeeded` later.
-    private func trackResponse(_ response: UNNotificationResponse) {
+    ///
+    /// Uses the supplied `appState` (captured at `handleNotificationResponse` time)
+    /// rather than the current app state, so cold-launch replays classify the
+    /// event correctly.
+    private func trackResponse(_ response: UNNotificationResponse, appState: UIApplication.State) {
         UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
             guard let self = self else { return }
             let authStatus = settings.authorizationStatus
             DispatchQueue.main.async {
+                // Re-check that this response is still pending and untracked.
+                // If the bridge already consumed and tracked it via
+                // consumePendingResponse(), bail out to avoid double-tracking.
+                self.responseLock.lock()
+                guard self.pendingResponse === response, !self.pendingResponseTracked else {
+                    self.responseLock.unlock()
+                    return
+                }
+                self.responseLock.unlock()
+
                 guard let nativeSDK = self.nativeSDK else {
                     // SDK not yet initialized (cold launch). The response stays cached
                     // with pendingResponseTracked = false. When the SDK is set via the
@@ -176,7 +203,7 @@ import UserNotifications
                     return
                 }
 
-                switch UIApplication.shared.applicationState {
+                switch appState {
                 case .active:
                     nativeSDK.handleForegroundPush(response: response, authorizationStatus: authStatus)
                 case .background, .inactive:
@@ -199,15 +226,17 @@ import UserNotifications
 
     /// Called from `sdk` didSet when the SDK becomes available.
     /// If there is a pending untracked response (cold-launch scenario),
-    /// track it now.
+    /// track it now using the app state captured at the original
+    /// `handleNotificationResponse` call.
     private func flushPendingResponseIfNeeded() {
         responseLock.lock()
         guard let response = pendingResponse, !pendingResponseTracked else {
             responseLock.unlock()
             return
         }
+        let appState = pendingAppState
         responseLock.unlock()
 
-        trackResponse(response)
+        trackResponse(response, appState: appState)
     }
 }

--- a/ios/Bridging/AttentiveSDKManager.swift
+++ b/ios/Bridging/AttentiveSDKManager.swift
@@ -51,6 +51,12 @@ import UserNotifications
 
     /// The most recent UNNotificationResponse, cached so the RN bridge can use it
     /// when JS calls handlePushOpen / handleForegroundPush.
+    ///
+    /// **Known limitation:** This is a single-slot cache. If two notifications
+    /// arrive in rapid succession (e.g. a tap followed immediately by a
+    /// foreground delivery), the second call to `handleNotificationResponse`
+    /// overwrites the first before its async tracking completes. In practice
+    /// this is extremely rare because `didReceive` is serialized by the system.
     private var pendingResponse: UNNotificationResponse?
 
     /// Whether the pending response has already been tracked via `handleNotificationResponse`.
@@ -106,46 +112,52 @@ import UserNotifications
      * @param response The `UNNotificationResponse` from the notification center delegate.
      */
     @objc public func handleNotificationResponse(_ response: UNNotificationResponse) {
-        // Capture app state NOW — by the time the async block or cold-launch
-        // replay runs, the app will likely be .active regardless of how it was
-        // actually launched. Storing the state ensures a killed-state push tap
-        // is correctly classified as a push open, not a foreground push.
-        let appState = UIApplication.shared.applicationState
+        // UIApplication.shared.applicationState is a UIKit property that must
+        // be read on the main thread. userNotificationCenter(_:didReceive:) is
+        // almost always delivered on main, but we guard defensively.
+        let cacheAndTrack = { [self] (appState: UIApplication.State) in
+            // Cache the response for the RN bridge (consumed by handlePushOpenFromRN /
+            // handleForegroundPushFromRN).
+            responseLock.lock()
+            pendingResponse = response
+            pendingResponseTracked = false
+            pendingAppState = appState
+            responseLock.unlock()
 
-        // Cache the response for the RN bridge (consumed by handlePushOpenFromRN / handleForegroundPushFromRN).
-        // pendingResponseTracked stays false until tracking actually executes, so a bridge
-        // call that races with the async block below will still track correctly.
-        responseLock.lock()
-        pendingResponse = response
-        pendingResponseTracked = false
-        pendingAppState = appState
-        responseLock.unlock()
+            trackResponse(response, appState: appState)
+        }
 
-        trackResponse(response, appState: appState)
+        if Thread.isMainThread {
+            cacheAndTrack(UIApplication.shared.applicationState)
+        } else {
+            DispatchQueue.main.async {
+                cacheAndTrack(UIApplication.shared.applicationState)
+            }
+        }
     }
 
-    // MARK: - Push Notification Handlers (for AppDelegate)
+    // MARK: - Push Notification Handlers (legacy — prefer handleNotificationResponse)
 
     /**
      * Handle a push notification when the app is in the foreground (active state).
-     * Call this from AppDelegate's userNotificationCenter(_:didReceive:withCompletionHandler:)
-     * when UIApplication.shared.applicationState == .active
      *
-     * @param response The UNNotificationResponse from the notification center delegate
-     * @param authorizationStatus Current push authorization status from notification settings
+     * - Important: Deprecated — use ``handleNotificationResponse(_:)`` instead,
+     *   which handles app-state detection and auth-status lookup automatically.
+     *   Do **not** call both methods for the same notification.
      */
+    @available(*, deprecated, message: "Use handleNotificationResponse(_:) instead")
     @objc public func handleForegroundPush(response: UNNotificationResponse, authorizationStatus: UNAuthorizationStatus) {
         nativeSDK?.handleForegroundPush(response: response, authorizationStatus: authorizationStatus)
     }
 
     /**
      * Handle when a push notification is opened by the user (app in background/inactive state).
-     * Call this from AppDelegate's userNotificationCenter(_:didReceive:withCompletionHandler:)
-     * when UIApplication.shared.applicationState == .background or .inactive
      *
-     * @param response The UNNotificationResponse from the notification center delegate
-     * @param authorizationStatus Current push authorization status from notification settings
+     * - Important: Deprecated — use ``handleNotificationResponse(_:)`` instead,
+     *   which handles app-state detection and auth-status lookup automatically.
+     *   Do **not** call both methods for the same notification.
      */
+    @available(*, deprecated, message: "Use handleNotificationResponse(_:) instead")
     @objc public func handlePushOpen(response: UNNotificationResponse, authorizationStatus: UNAuthorizationStatus) {
         nativeSDK?.handlePushOpen(response: response, authorizationStatus: authorizationStatus)
     }
@@ -186,40 +198,38 @@ import UserNotifications
             guard let self = self else { return }
             let authStatus = settings.authorizationStatus
             DispatchQueue.main.async {
-                // Re-check that this response is still pending and untracked.
-                // If the bridge already consumed and tracked it via
-                // consumePendingResponse(), bail out to avoid double-tracking.
+                // Check that this response is still pending and untracked, then
+                // mark tracked optimistically *before* releasing the lock. This
+                // closes the window where consumePendingResponse() could run on
+                // another thread, see alreadyTracked: false, and also call the
+                // native SDK — resulting in double-tracking.
                 self.responseLock.lock()
                 guard self.pendingResponse === response, !self.pendingResponseTracked else {
                     self.responseLock.unlock()
                     return
                 }
-                self.responseLock.unlock()
 
-                guard let nativeSDK = self.nativeSDK else {
-                    // SDK not yet initialized (cold launch). The response stays cached
-                    // with pendingResponseTracked = false. When the SDK is set via the
-                    // RN bridge, the didSet observer will call flushPendingResponseIfNeeded.
+                guard self.nativeSDK != nil else {
+                    // SDK not yet initialized (cold launch). Leave
+                    // pendingResponseTracked = false so the didSet observer
+                    // on `sdk` can flush later.
+                    self.responseLock.unlock()
                     return
                 }
 
+                // Mark tracked while still holding the lock, before the SDK call.
+                self.pendingResponseTracked = true
+                self.responseLock.unlock()
+
+                // Safe to call outside the lock — we've already claimed ownership.
                 switch appState {
                 case .active:
-                    nativeSDK.handleForegroundPush(response: response, authorizationStatus: authStatus)
+                    self.nativeSDK?.handleForegroundPush(response: response, authorizationStatus: authStatus)
                 case .background, .inactive:
-                    nativeSDK.handlePushOpen(response: response, authorizationStatus: authStatus)
+                    self.nativeSDK?.handlePushOpen(response: response, authorizationStatus: authStatus)
                 @unknown default:
-                    nativeSDK.handlePushOpen(response: response, authorizationStatus: authStatus)
+                    self.nativeSDK?.handlePushOpen(response: response, authorizationStatus: authStatus)
                 }
-
-                // Mark tracked only after the native SDK call has actually executed.
-                // If the bridge consumed the response first (pendingResponse is now nil
-                // or points to a different notification), skip — the bridge already handled it.
-                self.responseLock.lock()
-                if self.pendingResponse === response {
-                    self.pendingResponseTracked = true
-                }
-                self.responseLock.unlock()
             }
         }
     }

--- a/ios/Bridging/AttentiveSDKManager.swift
+++ b/ios/Bridging/AttentiveSDKManager.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 import UserNotifications
 
 /**
@@ -14,21 +15,21 @@ import UserNotifications
  * This allows AppDelegate and other native code to access the SDK instance
  * that was initialized from React Native.
  *
- * Usage in AppDelegate:
+ * ## Minimal Integration (recommended)
+ *
+ * In your AppDelegate's `userNotificationCenter(_:didReceive:withCompletionHandler:)`,
+ * add **one line** to enable push-open and foreground-push tracking:
+ *
  * ```swift
- * // In userNotificationCenter(_:didReceive:withCompletionHandler:)
- * UNUserNotificationCenter.current().getNotificationSettings { settings in
- *   let authStatus = settings.authorizationStatus
- *   DispatchQueue.main.async {
- *     switch UIApplication.shared.applicationState {
- *     case .active:
- *       AttentiveSDKManager.shared.handleForegroundPush(response: response, authorizationStatus: authStatus)
- *     case .background, .inactive:
- *       AttentiveSDKManager.shared.handlePushOpen(response: response, authorizationStatus: authStatus)
- *     @unknown default:
- *       AttentiveSDKManager.shared.handlePushOpen(response: response, authorizationStatus: authStatus)
- *     }
- *   }
+ * func userNotificationCenter(_ center: UNUserNotificationCenter,
+ *                             didReceive response: UNNotificationResponse,
+ *                             withCompletionHandler completionHandler: @escaping () -> Void) {
+ *     // Track push interaction with Attentive (handles app-state detection + auth status internally)
+ *     AttentiveSDKManager.shared.handleNotificationResponse(response)
+ *
+ *     // Forward to your push library (e.g. RNCPushNotificationIOS) for JS-side handling
+ *     RNCPushNotificationIOS.didReceive(response)
+ *     completionHandler()
  * }
  * ```
  */
@@ -36,10 +37,28 @@ import UserNotifications
     /// Shared singleton instance
     @objc public static let shared: AttentiveSDKManager = AttentiveSDKManager()
 
-    /// The Attentive SDK instance as AnyObject for Objective-C compatibility
-    /// This should be set when the SDK is initialized from React Native
-    /// Cast to ATTNNativeSDK in Swift code
-    @objc public var sdk: AnyObject?
+    /// The Attentive SDK instance as AnyObject for Objective-C compatibility.
+    /// When set, any pending (untracked) notification response is automatically flushed.
+    @objc public var sdk: AnyObject? {
+        didSet {
+            if sdk != nil {
+                flushPendingResponseIfNeeded()
+            }
+        }
+    }
+
+    // MARK: - Notification Response Cache
+
+    /// The most recent UNNotificationResponse, cached so the RN bridge can use it
+    /// when JS calls handlePushOpen / handleForegroundPush.
+    private var pendingResponse: UNNotificationResponse?
+
+    /// Whether the pending response has already been tracked via `handleNotificationResponse`.
+    /// Prevents double-tracking when both the native convenience method and the JS bridge fire.
+    private var pendingResponseTracked: Bool = false
+
+    /// Serialises access to the cache fields above.
+    private let responseLock = NSLock()
 
     private override init() {
         super.init()
@@ -53,6 +72,43 @@ import UserNotifications
     /// Helper method to set the SDK instance with proper type in Swift
     public func setNativeSDK(_ nativeSDK: ATTNNativeSDK?) {
         sdk = nativeSDK
+    }
+
+    // MARK: - Push Notification Convenience Method
+
+    /**
+     * Handle a push notification response in one call.
+     *
+     * This is the **recommended** way to track push interactions on iOS.
+     * It automatically determines the app state, fetches the current
+     * authorization status, and calls the appropriate native SDK method
+     * (`handlePushOpen` or `handleForegroundPush`).
+     *
+     * Call this from your AppDelegate's
+     * `userNotificationCenter(_:didReceive:withCompletionHandler:)`.
+     *
+     * The response is also cached so that if the JS layer later calls
+     * `handlePushOpen()` or `handleForegroundPush()` via the RN bridge,
+     * the bridge can fulfil the call using the real `UNNotificationResponse`
+     * without double-tracking.
+     *
+     * **Cold-launch safety:** If the SDK has not yet been initialized (e.g. the
+     * app was launched from a killed state via a push tap), the response is
+     * cached and will be automatically tracked once `sdk` is set during RN
+     * bridge initialization.
+     *
+     * @param response The `UNNotificationResponse` from the notification center delegate.
+     */
+    @objc public func handleNotificationResponse(_ response: UNNotificationResponse) {
+        // Cache the response for the RN bridge (consumed by handlePushOpenFromRN / handleForegroundPushFromRN).
+        // pendingResponseTracked stays false until tracking actually executes, so a bridge
+        // call that races with the async block below will still track correctly.
+        responseLock.lock()
+        pendingResponse = response
+        pendingResponseTracked = false
+        responseLock.unlock()
+
+        trackResponse(response)
     }
 
     // MARK: - Push Notification Handlers (for AppDelegate)
@@ -79,5 +135,79 @@ import UserNotifications
      */
     @objc public func handlePushOpen(response: UNNotificationResponse, authorizationStatus: UNAuthorizationStatus) {
         nativeSDK?.handlePushOpen(response: response, authorizationStatus: authorizationStatus)
+    }
+
+    // MARK: - Response Cache (internal, used by RN bridge)
+
+    /**
+     * Consume the cached notification response.
+     *
+     * Returns the cached `UNNotificationResponse` and whether it was already
+     * tracked by `handleNotificationResponse`. The bridge uses this to decide
+     * whether to call the native SDK again.
+     *
+     * After this call the cache is cleared.
+     */
+    func consumePendingResponse() -> (response: UNNotificationResponse, alreadyTracked: Bool)? {
+        responseLock.lock()
+        defer { responseLock.unlock() }
+
+        guard let response = pendingResponse else { return nil }
+        let tracked = pendingResponseTracked
+        pendingResponse = nil
+        pendingResponseTracked = false
+        return (response, tracked)
+    }
+
+    // MARK: - Private
+
+    /// Attempt to track a cached response via the native SDK.
+    /// If nativeSDK is nil (cold launch), returns without marking tracked;
+    /// the `sdk` didSet will call `flushPendingResponseIfNeeded` later.
+    private func trackResponse(_ response: UNNotificationResponse) {
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            guard let self = self else { return }
+            let authStatus = settings.authorizationStatus
+            DispatchQueue.main.async {
+                guard let nativeSDK = self.nativeSDK else {
+                    // SDK not yet initialized (cold launch). The response stays cached
+                    // with pendingResponseTracked = false. When the SDK is set via the
+                    // RN bridge, the didSet observer will call flushPendingResponseIfNeeded.
+                    return
+                }
+
+                switch UIApplication.shared.applicationState {
+                case .active:
+                    nativeSDK.handleForegroundPush(response: response, authorizationStatus: authStatus)
+                case .background, .inactive:
+                    nativeSDK.handlePushOpen(response: response, authorizationStatus: authStatus)
+                @unknown default:
+                    nativeSDK.handlePushOpen(response: response, authorizationStatus: authStatus)
+                }
+
+                // Mark tracked only after the native SDK call has actually executed.
+                // If the bridge consumed the response first (pendingResponse is now nil
+                // or points to a different notification), skip — the bridge already handled it.
+                self.responseLock.lock()
+                if self.pendingResponse === response {
+                    self.pendingResponseTracked = true
+                }
+                self.responseLock.unlock()
+            }
+        }
+    }
+
+    /// Called from `sdk` didSet when the SDK becomes available.
+    /// If there is a pending untracked response (cold-launch scenario),
+    /// track it now.
+    private func flushPendingResponseIfNeeded() {
+        responseLock.lock()
+        guard let response = pendingResponse, !pendingResponseTracked else {
+            responseLock.unlock()
+            return
+        }
+        responseLock.unlock()
+
+        trackResponse(response)
     }
 }

--- a/src/NativeAttentiveReactNativeSdk.ts
+++ b/src/NativeAttentiveReactNativeSdk.ts
@@ -1,5 +1,5 @@
-import type { TurboModule } from "react-native/Libraries/TurboModule/RCTExport";
-import { TurboModuleRegistry, NativeModules } from "react-native";
+import type { TurboModule } from 'react-native/Libraries/TurboModule/RCTExport'
+import { TurboModuleRegistry, NativeModules } from 'react-native'
 
 export interface Spec extends TurboModule {
   initialize: (
@@ -7,10 +7,10 @@ export interface Spec extends TurboModule {
     mode: string,
     skipFatigueOnCreatives: boolean,
     enableDebugger: boolean
-  ) => void;
-  triggerCreative: (creativeId?: string) => void;
-  destroyCreative: () => void;
-  updateDomain: (domain: string) => void;
+  ) => void
+  triggerCreative: (creativeId?: string) => void
+  destroyCreative: () => void
+  updateDomain: (domain: string) => void
   identify: (
     phone?: string,
     email?: string,
@@ -18,52 +18,52 @@ export interface Spec extends TurboModule {
     shopifyId?: string,
     clientUserId?: string,
     customIdentifiers?: Object
-  ) => void;
-  clearUser: () => void;
+  ) => void
+  clearUser: () => void
   recordAddToCartEvent: (
     items: Array<{
-      productId: string;
-      productVariantId: string;
-      price: string;
-      currency: string;
-      productImage?: string;
-      name?: string;
-      quantity?: number;
-      category?: string;
+      productId: string
+      productVariantId: string
+      price: string
+      currency: string
+      productImage?: string
+      name?: string
+      quantity?: number
+      category?: string
     }>,
     deeplink?: string
-  ) => void;
+  ) => void
   recordProductViewEvent: (
     items: Array<{
-      productId: string;
-      productVariantId: string;
-      price: string;
-      currency: string;
-      productImage?: string;
-      name?: string;
-      quantity?: number;
-      category?: string;
+      productId: string
+      productVariantId: string
+      price: string
+      currency: string
+      productImage?: string
+      name?: string
+      quantity?: number
+      category?: string
     }>,
     deeplink?: string
-  ) => void;
+  ) => void
   recordPurchaseEvent: (
     items: Array<{
-      productId: string;
-      productVariantId: string;
-      price: string;
-      currency: string;
-      productImage?: string;
-      name?: string;
-      quantity?: number;
-      category?: string;
+      productId: string
+      productVariantId: string
+      price: string
+      currency: string
+      productImage?: string
+      name?: string
+      quantity?: number
+      category?: string
     }>,
     orderId: string,
     cartId?: string,
     cartCoupon?: string
-  ) => void;
-  recordCustomEvent: (type: string, properties: Object) => void;
-  invokeAttentiveDebugHelper: () => void;
-  exportDebugLogs: () => Promise<string>;
+  ) => void
+  recordCustomEvent: (type: string, properties: Object) => void
+  invokeAttentiveDebugHelper: () => void
+  exportDebugLogs: () => Promise<string>
 
   // Push Notification Methods
   /**
@@ -100,8 +100,13 @@ export interface Spec extends TurboModule {
   registerDeviceTokenWithCallback: (
     token: string,
     authorizationStatus: string,
-    callback: (data?: Object, url?: string, response?: Object, error?: Object) => void
-  ) => void;
+    callback: (
+      data?: Object,
+      url?: string,
+      response?: Object,
+      error?: Object
+    ) => void
+  ) => void
 
   /**
    * Handle regular/direct app open (not from a push notification).
@@ -109,7 +114,7 @@ export interface Spec extends TurboModule {
    * This should be called after device token registration to track app opens.
    * @param authorizationStatus - Current push authorization status
    */
-  handleRegularOpen: (authorizationStatus: string) => void;
+  handleRegularOpen: (authorizationStatus: string) => void
 
   /**
    * Handle when a push notification is opened by the user.
@@ -122,7 +127,7 @@ export interface Spec extends TurboModule {
     userInfo: Object,
     applicationState: string,
     authorizationStatus: string
-  ) => void;
+  ) => void
 
   /**
    * Handle when a push notification arrives while the app is in foreground.
@@ -167,7 +172,7 @@ export interface Spec extends TurboModule {
 const isTurboModuleEnabled = (global as any).__turboModuleProxy != null
 
 const AttentiveReactNativeSdkModule = isTurboModuleEnabled
-  ? TurboModuleRegistry.get<Spec>("AttentiveReactNativeSdk")
+  ? TurboModuleRegistry.get<Spec>('AttentiveReactNativeSdk')
   : NativeModules.AttentiveReactNativeSdk
 
 export default AttentiveReactNativeSdkModule as Spec | null

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -483,7 +483,10 @@ function handlePushOpen(
  * @returns A promise that resolves to the notification data object, or `null` if the
  *          app was not launched via a push notification tap.
  */
-async function getInitialPushNotification(): Promise<Record<string, string> | null> {
+async function getInitialPushNotification(): Promise<Record<
+  string,
+  string
+> | null> {
   const result = await AttentiveReactNativeSdk.getInitialPushNotification()
   return result as Record<string, string> | null
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -385,17 +385,16 @@ function handleForegroundNotification(
 
 /**
  * Handle a push notification when the app is in the foreground (active state).
- * This is the React Native equivalent of the native iOS handleForegroundPush method.
  *
  * Call this when you receive a notification response and the app state is 'active'.
- * This is part of implementing the native iOS pattern:
- * ```swift
- * case .active:
- *   self.attentiveSdk?.handleForegroundPush(response: response, authorizationStatus: authStatus)
- * ```
  *
- * On iOS, this properly tracks foreground push notifications.
- * On Android, registers the FCM token when provided by the host app.
+ * **iOS prerequisite:** Your AppDelegate's
+ * `userNotificationCenter(_:didReceive:withCompletionHandler:)` must call
+ * `AttentiveSDKManager.shared.handleNotificationResponse(response)` so that
+ * the SDK can cache the `UNNotificationResponse` required by the native iOS SDK.
+ * Without that one line of native code, this function cannot track the event.
+ *
+ * On Android, this tracks the foreground push as a custom event.
  *
  * @param userInfo - The notification payload from the push notification
  * @param authorizationStatus - Current push authorization status
@@ -424,17 +423,16 @@ function handleForegroundPush(
 
 /**
  * Handle when a push notification is opened by the user (app in background/inactive state).
- * This is the React Native equivalent of the native iOS handlePushOpen method.
  *
  * Call this when you receive a notification response and the app state is 'background' or 'inactive'.
- * This is part of implementing the native iOS pattern:
- * ```swift
- * case .background, .inactive:
- *   self.attentiveSdk?.handlePushOpen(response: response, authorizationStatus: authStatus)
- * ```
  *
- * On iOS, this properly tracks push notification opens.
- * On Android, registers the FCM token when provided by the host app.
+ * **iOS prerequisite:** Your AppDelegate's
+ * `userNotificationCenter(_:didReceive:withCompletionHandler:)` must call
+ * `AttentiveSDKManager.shared.handleNotificationResponse(response)` so that
+ * the SDK can cache the `UNNotificationResponse` required by the native iOS SDK.
+ * Without that one line of native code, this function cannot track the event.
+ *
+ * On Android, this tracks the push open as a custom event.
  *
  * @param userInfo - The notification payload from the push notification
  * @param authorizationStatus - Current push authorization status

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,6 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext"
-  }
+  },
+  "exclude": ["Bonni", "example", "node_modules", "**/__tests__"]
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `handlePushOpen()` and `handleForegroundPush()` called from JavaScript were silent no-ops on iOS because the native SDK requires a `UNNotificationResponse` object that cannot cross the React Native bridge. This caused all push interactions to be recorded as `AppLaunched` instead of `PushMessageDirectOpen`.
- **Fix:** Introduces a response-caching pattern in `AttentiveSDKManager` — clients add one line to their AppDelegate (`AttentiveSDKManager.shared.handleNotificationResponse(response)`) and all push tracking works correctly, including cold-launch scenarios.
- **Impact:** Resolves four client-reported issues (The Range): missing Push Opened events, excessive App Launched activity, missing utm_source attribution, and apparent campaign push delivery failures (pushes were delivered but tracking was broken so no evidence was visible).

### Changes

| File | What changed |
|---|---|
| `ios/Bridging/AttentiveSDKManager.swift` | Added `handleNotificationResponse(_:)` convenience method, response caching with thread-safe lock, `sdk` `didSet` observer for cold-launch flush |
| `ios/Bridging/ATTNNativeSDK.swift` | `handlePushOpenFromRN` and `handleForegroundPushFromRN` now consume cached responses instead of being no-ops; double-tracking prevention |
| `Bonni/ios/Bonni/AppDelegate.swift` | Simplified to use new one-liner |
| `README.md` | Added prominent iOS setup callout + "Push Open Tracking (Required)" section |
| `src/index.tsx` | Updated JSDoc for `handleForegroundPush` and `handlePushOpen` |

### Client action required

One line in their AppDelegate's `didReceive` handler:

```swift
AttentiveSDKManager.shared.handleNotificationResponse(response)
```

## Test plan

- [ ] Verify push open tracking works on iOS (background/inactive tap generates `PushMessageDirectOpen` event)
- [ ] Verify foreground push tracking works on iOS (notification tap while app is active)
- [ ] Verify cold-launch scenario (app killed → push tap → SDK initializes → event is tracked)
- [ ] Verify no double-tracking when both native and JS bridge paths fire
- [ ] Verify Android push tracking is unaffected
- [ ] Verify Bonni example app still works correctly with simplified AppDelegate

🤖 Generated with [Claude Code](https://claude.com/claude-code)