### PR TITLE
[MSDK-255] Allow users to directly edit domain name

### DIFF
--- a/Bonni/__tests__/useTextPrompt.test.tsx
+++ b/Bonni/__tests__/useTextPrompt.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Tests for the useTextPrompt cross-platform hook.
+ *
+ * Strategy:
+ * - Mock `Platform.OS` to exercise both the iOS (Alert.prompt) and Android (modal) paths.
+ * - Use `@testing-library/react-native`'s `renderHook` + `act` for hook state changes.
+ * - Verify Alert.prompt is called on iOS and NOT on Android (and vice-versa for state).
+ */
+
+import React from 'react'
+import { renderHook, act } from '@testing-library/react-native'
+import { Alert, Platform } from 'react-native'
+import { useTextPrompt } from '../src/hooks/useTextPrompt'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Override Platform.OS for the duration of a test. */
+function setPlatform(os: 'ios' | 'android') {
+  Object.defineProperty(Platform, 'OS', { get: () => os, configurable: true })
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const mockAlertPrompt = jest.spyOn(Alert, 'prompt').mockImplementation(() => {})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// iOS path
+// ---------------------------------------------------------------------------
+
+describe('useTextPrompt – iOS', () => {
+  beforeEach(() => setPlatform('ios'))
+
+  it('calls Alert.prompt with the correct title and message', () => {
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({
+        title: 'Test Title',
+        message: 'Test message',
+        defaultValue: 'default',
+        onConfirm: jest.fn(),
+      })
+    })
+
+    expect(mockAlertPrompt).toHaveBeenCalledTimes(1)
+    expect(mockAlertPrompt).toHaveBeenCalledWith(
+      'Test Title',
+      'Test message',
+      expect.any(Array),
+      'plain-text',
+      'default',
+    )
+  })
+
+  it('returns null for PromptModal on iOS', () => {
+    const { result } = renderHook(() => useTextPrompt())
+    expect(result.current.PromptModal).toBeNull()
+  })
+
+  it('invokes onConfirm with trimmed value via the confirm button handler', () => {
+    const onConfirm = jest.fn()
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({ title: 'T', defaultValue: '', onConfirm })
+    })
+
+    // Extract and invoke the "Save" button's onPress from the Alert.prompt call
+    const buttons: any[] = mockAlertPrompt.mock.calls[0][2] as any[]
+    const confirmButton = buttons.find((b: any) => b.text !== 'Cancel')
+    act(() => {
+      confirmButton.onPress('  hello world  ')
+    })
+
+    expect(onConfirm).toHaveBeenCalledWith('hello world')
+  })
+
+  it('does NOT invoke onConfirm when value is empty after trimming', () => {
+    const onConfirm = jest.fn()
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({ title: 'T', defaultValue: '', onConfirm })
+    })
+
+    const buttons: any[] = mockAlertPrompt.mock.calls[0][2] as any[]
+    const confirmButton = buttons.find((b: any) => b.text !== 'Cancel')
+    act(() => {
+      confirmButton.onPress('   ')
+    })
+
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('invokes onCancel via the cancel button handler', () => {
+    const onCancel = jest.fn()
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({ title: 'T', onConfirm: jest.fn(), onCancel })
+    })
+
+    const buttons: any[] = mockAlertPrompt.mock.calls[0][2] as any[]
+    const cancelButton = buttons.find((b: any) => b.style === 'cancel')
+    act(() => {
+      cancelButton.onPress()
+    })
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Android path
+// ---------------------------------------------------------------------------
+
+describe('useTextPrompt – Android', () => {
+  beforeEach(() => setPlatform('android'))
+
+  it('does NOT call Alert.prompt on Android', () => {
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({ title: 'T', onConfirm: jest.fn() })
+    })
+
+    expect(mockAlertPrompt).not.toHaveBeenCalled()
+  })
+
+  it('returns a non-null PromptModal element on Android', () => {
+    const { result } = renderHook(() => useTextPrompt())
+    expect(result.current.PromptModal).not.toBeNull()
+  })
+
+  it('PromptModal starts with visible=false', () => {
+    const { result } = renderHook(() => useTextPrompt())
+    // Modal element exists but should not be visible initially
+    const modal = result.current.PromptModal as React.ReactElement
+    expect(modal.props.visible).toBe(false)
+  })
+
+  it('sets PromptModal to visible after showPrompt is called', () => {
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({ title: 'Domain', defaultValue: 'games', onConfirm: jest.fn() })
+    })
+
+    const modal = result.current.PromptModal as React.ReactElement
+    expect(modal.props.visible).toBe(true)
+    expect(modal.props.title).toBe('Domain')
+    expect(modal.props.defaultValue).toBe('games')
+  })
+
+  it('hides the modal and calls onConfirm with trimmed value on confirm', () => {
+    const onConfirm = jest.fn()
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({ title: 'T', onConfirm })
+    })
+
+    // Simulate the modal calling onConfirm
+    act(() => {
+      const modal = result.current.PromptModal as React.ReactElement
+      modal.props.onConfirm('  staging  ')
+    })
+
+    const modal = result.current.PromptModal as React.ReactElement
+    expect(modal.props.visible).toBe(false)
+    expect(onConfirm).toHaveBeenCalledWith('staging')
+  })
+
+  it('hides the modal but does NOT call onConfirm for empty input', () => {
+    const onConfirm = jest.fn()
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({ title: 'T', onConfirm })
+    })
+
+    act(() => {
+      const modal = result.current.PromptModal as React.ReactElement
+      modal.props.onConfirm('   ')
+    })
+
+    const modal = result.current.PromptModal as React.ReactElement
+    expect(modal.props.visible).toBe(false)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('hides the modal and calls onCancel on dismiss', () => {
+    const onCancel = jest.fn()
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({ title: 'T', onConfirm: jest.fn(), onCancel })
+    })
+
+    act(() => {
+      const modal = result.current.PromptModal as React.ReactElement
+      modal.props.onDismiss()
+    })
+
+    const modal = result.current.PromptModal as React.ReactElement
+    expect(modal.props.visible).toBe(false)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses custom confirmText and cancelText when provided', () => {
+    const { result } = renderHook(() => useTextPrompt())
+
+    act(() => {
+      result.current.showPrompt({
+        title: 'T',
+        confirmText: 'Apply',
+        cancelText: 'Discard',
+        onConfirm: jest.fn(),
+      })
+    })
+
+    const modal = result.current.PromptModal as React.ReactElement
+    expect(modal.props.confirmText).toBe('Apply')
+    expect(modal.props.cancelText).toBe('Discard')
+  })
+})

--- a/Bonni/ios/Podfile.lock
+++ b/Bonni/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - attentive-ios-sdk (2.0.13)
-  - attentive-react-native-sdk (2.0.1):
+  - attentive-react-native-sdk (2.0.2):
     - attentive-ios-sdk (= 2.0.13)
     - DoubleConversion
     - glog
@@ -1956,7 +1956,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   attentive-ios-sdk: 087b97afeefcf0a3a3763bd003f0bb0a166b3ed4
-  attentive-react-native-sdk: 87a75a4255ce4d19b0866feaf2ec2a7362d44cf1
+  attentive-react-native-sdk: 87a2ebc3763f5ba2e6c1e1a98ef4e8a60fa130f1
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6

--- a/Bonni/package-lock.json
+++ b/Bonni/package-lock.json
@@ -32,7 +32,6 @@
         "@react-native/eslint-config": "0.77.3",
         "@react-native/metro-config": "0.77.3",
         "@react-native/typescript-config": "0.77.3",
-        "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.13",
         "@types/react": "^18.2.6",
@@ -3882,61 +3881,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@testing-library/jest-native": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.3.tgz",
-      "integrity": "sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==",
-      "deprecated": "DEPRECATED: This package is no longer maintained.\nPlease use the built-in Jest matchers available in @testing-library/react-native v12.4+.\n\nSee migration guide: https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "jest-diff": "^29.0.1",
-        "jest-matcher-utils": "^29.0.1",
-        "pretty-format": "^29.0.3",
-        "redent": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-native": ">=0.59",
-        "react-test-renderer": ">=16.0.0"
-      }
-    },
-    "node_modules/@testing-library/jest-native/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/jest-native/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@testing-library/jest-native/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@testing-library/react-native": {
       "version": "13.3.3",

--- a/Bonni/package-lock.json
+++ b/Bonni/package-lock.json
@@ -32,6 +32,8 @@
         "@react-native/eslint-config": "0.77.3",
         "@react-native/metro-config": "0.77.3",
         "@react-native/typescript-config": "0.77.3",
+        "@testing-library/jest-native": "^5.4.3",
+        "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.13",
         "@types/react": "^18.2.6",
         "@types/react-test-renderer": "^18.0.0",
@@ -48,7 +50,7 @@
     },
     "..": {
       "name": "@attentive-mobile/attentive-react-native-sdk",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",
@@ -2458,6 +2460,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2515,6 +2527,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -3859,6 +3881,169 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/jest-native": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.3.tgz",
+      "integrity": "sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==",
+      "deprecated": "DEPRECATED: This package is no longer maintained.\nPlease use the built-in Jest matchers available in @testing-library/react-native v12.4+.\n\nSee migration guide: https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-diff": "^29.0.1",
+        "jest-matcher-utils": "^29.0.1",
+        "pretty-format": "^29.0.3",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.3.tgz",
+      "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.0.5",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.0.5",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@trysound/sax": {
@@ -7841,6 +8026,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -10525,6 +10720,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -11457,6 +11662,22 @@
       "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
       "license": "MIT"
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-native": {
       "version": "0.77.3",
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.77.3.tgz",
@@ -11790,6 +12011,20 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12881,6 +13116,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/Bonni/package.json
+++ b/Bonni/package.json
@@ -38,6 +38,8 @@
     "@react-native/eslint-config": "0.77.3",
     "@react-native/metro-config": "0.77.3",
     "@react-native/typescript-config": "0.77.3",
+    "@testing-library/jest-native": "^5.4.3",
+    "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.13",
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",

--- a/Bonni/package.json
+++ b/Bonni/package.json
@@ -38,7 +38,6 @@
     "@react-native/eslint-config": "0.77.3",
     "@react-native/metro-config": "0.77.3",
     "@react-native/typescript-config": "0.77.3",
-    "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.13",
     "@types/react": "^18.2.6",

--- a/Bonni/src/components/TextPromptModal.tsx
+++ b/Bonni/src/components/TextPromptModal.tsx
@@ -1,0 +1,208 @@
+/**
+ * Cross-platform text-input dialog used on Android (iOS uses Alert.prompt natively).
+ * Renders a Modal overlay containing a title, optional message, a TextInput
+ * pre-filled with `defaultValue`, and Cancel / Confirm buttons.
+ */
+
+import React, { useEffect, useRef, useState } from 'react'
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  StyleSheet,
+  KeyboardAvoidingView,
+} from 'react-native'
+import { Colors, Typography, Spacing, BorderRadius } from '../constants/theme'
+
+export interface TextPromptModalProps {
+  /** Controls visibility of the modal. */
+  visible: boolean
+  /** Dialog title displayed in bold at the top. */
+  title: string
+  /** Optional subtitle/body text shown below the title. */
+  message?: string
+  /** Pre-filled value for the text input. */
+  defaultValue?: string
+  /** Placeholder text shown when the input is empty. */
+  placeholder?: string
+  /** Label for the confirm button. Defaults to "Save". */
+  confirmText?: string
+  /** Label for the cancel button. Defaults to "Cancel". */
+  cancelText?: string
+  /** Called with the current input value when the user confirms. */
+  onConfirm: (value: string) => void
+  /** Called when the user dismisses the dialog without confirming. */
+  onDismiss: () => void
+}
+
+/**
+ * Android-only inline text prompt that mimics the iOS `Alert.prompt` behaviour.
+ * On iOS this component should never be rendered (the hook guards that).
+ */
+export const TextPromptModal: React.FC<TextPromptModalProps> = ({
+  visible,
+  title,
+  message,
+  defaultValue = '',
+  placeholder,
+  confirmText = 'Save',
+  cancelText = 'Cancel',
+  onConfirm,
+  onDismiss,
+}) => {
+  const [value, setValue] = useState(defaultValue)
+  const inputRef = useRef<TextInput>(null)
+
+  // Sync internal value whenever the dialog re-opens with a new defaultValue
+  useEffect(() => {
+    if (visible) {
+      setValue(defaultValue)
+      // Small delay lets the Modal finish its entrance animation before focusing
+      setTimeout(() => inputRef.current?.focus(), 100)
+    }
+  }, [visible, defaultValue])
+
+  const handleConfirm = () => {
+    onConfirm(value)
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onDismiss}
+    >
+      <Pressable style={styles.backdrop} onPress={onDismiss}>
+        {/* Stop touch events from bubbling through the dialog card */}
+        <KeyboardAvoidingView behavior="padding">
+          <Pressable style={styles.card} onPress={() => {}}>
+            {/* Header */}
+            <Text style={styles.title}>{title}</Text>
+            {message ? <Text style={styles.message}>{message}</Text> : null}
+
+            {/* Input */}
+            <TextInput
+              ref={inputRef}
+              style={styles.input}
+              value={value}
+              onChangeText={setValue}
+              placeholder={placeholder}
+              placeholderTextColor={Colors.secondaryText}
+              autoCapitalize="none"
+              autoCorrect={false}
+              returnKeyType="done"
+              onSubmitEditing={handleConfirm}
+            />
+
+            {/* Actions */}
+            <View style={styles.actions}>
+              <Pressable
+                style={({ pressed }) => [styles.button, styles.cancelButton, pressed && styles.buttonPressed]}
+                onPress={onDismiss}
+                accessibilityRole="button"
+                accessibilityLabel={cancelText}
+              >
+                <Text style={styles.cancelButtonText}>{cancelText}</Text>
+              </Pressable>
+
+              <View style={styles.buttonDivider} />
+
+              <Pressable
+                style={({ pressed }) => [styles.button, styles.confirmButton, pressed && styles.buttonPressed]}
+                onPress={handleConfirm}
+                accessibilityRole="button"
+                accessibilityLabel={confirmText}
+              >
+                <Text style={styles.confirmButtonText}>{confirmText}</Text>
+              </Pressable>
+            </View>
+          </Pressable>
+        </KeyboardAvoidingView>
+      </Pressable>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.xl,
+  },
+  card: {
+    width: '100%',
+    backgroundColor: Colors.white,
+    borderRadius: BorderRadius.medium,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    paddingTop: Spacing.xl,
+    paddingHorizontal: Spacing.xl,
+    paddingBottom: 0,
+    // Prevent the Pressable from collapsing to 0-size
+    minWidth: 280,
+  },
+  title: {
+    fontSize: Typography.sizes.large,
+    fontWeight: Typography.weights.semibold,
+    color: Colors.primaryText,
+    textAlign: 'center',
+    marginBottom: Spacing.sm,
+  },
+  message: {
+    fontSize: Typography.sizes.small,
+    color: Colors.secondaryText,
+    textAlign: 'center',
+    marginBottom: Spacing.base,
+    lineHeight: 20,
+  },
+  input: {
+    height: 44,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.small,
+    paddingHorizontal: Spacing.md,
+    fontSize: Typography.sizes.medium,
+    color: Colors.primaryText,
+    marginBottom: Spacing.xl,
+  },
+  actions: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: Colors.lightBackground,
+    marginHorizontal: -Spacing.xl,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: Spacing.base,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonPressed: {
+    backgroundColor: Colors.lightBackground,
+  },
+  cancelButton: {
+    borderBottomLeftRadius: BorderRadius.medium,
+  },
+  confirmButton: {
+    borderBottomRightRadius: BorderRadius.medium,
+  },
+  buttonDivider: {
+    width: 1,
+    backgroundColor: Colors.lightBackground,
+  },
+  cancelButtonText: {
+    fontSize: Typography.sizes.medium,
+    color: Colors.secondaryText,
+    fontWeight: Typography.weights.medium,
+  },
+  confirmButtonText: {
+    fontSize: Typography.sizes.medium,
+    color: Colors.primaryText,
+    fontWeight: Typography.weights.semibold,
+  },
+})

--- a/Bonni/src/hooks/index.ts
+++ b/Bonni/src/hooks/index.ts
@@ -7,4 +7,5 @@ export { useProductView, useAddToCart, usePurchase } from './useAttentiveEvents'
 export { useAttentiveUser } from './useAttentiveUser'
 export { useAttentiveActions } from './useAttentiveActions'
 export { useDisplayAlerts } from './useDisplayAlerts'
+export { useAttentiveDomain } from './useAttentiveDomain'
 

--- a/Bonni/src/hooks/index.ts
+++ b/Bonni/src/hooks/index.ts
@@ -8,4 +8,5 @@ export { useAttentiveUser } from './useAttentiveUser'
 export { useAttentiveActions } from './useAttentiveActions'
 export { useDisplayAlerts } from './useDisplayAlerts'
 export { useAttentiveDomain } from './useAttentiveDomain'
+export { useTextPrompt } from './useTextPrompt'
 

--- a/Bonni/src/hooks/useAttentiveDomain.ts
+++ b/Bonni/src/hooks/useAttentiveDomain.ts
@@ -51,7 +51,7 @@ export function useAttentiveDomain(): AttentiveDomainHook {
    * Persists a new domain, updates local state, and notifies the SDK.
    *
    * @param newDomain - Raw string entered by the user.
-   * @throws Does not throw; surfaces errors via Alert.
+   * @throws Does not throw; errors are logged to the console.
    */
   const saveDomain = useCallback(async (newDomain: string) => {
     const trimmed = newDomain.trim()
@@ -60,10 +60,8 @@ export function useAttentiveDomain(): AttentiveDomainHook {
       setDomain(trimmed)
       await AsyncStorage.setItem(DOMAIN_STORAGE_KEY, trimmed)
       updateDomain(trimmed)
-      Alert.alert('Success', `Domain updated to: ${trimmed}`)
     } catch (error) {
       console.error('Error saving domain setting:', error)
-      Alert.alert('Error', 'Failed to save domain setting')
     }
   }, [])
 
@@ -73,14 +71,14 @@ export function useAttentiveDomain(): AttentiveDomainHook {
    */
   const promptForDomain = useCallback(() => {
     Alert.prompt(
-      'Attentive Domain',
-      'Enter your domain name',
+      'Switch Domain',
+      'Enter the new domain',
       [
         { text: 'Cancel', style: 'cancel' },
         {
           text: 'Save',
           onPress: (value) => {
-            if (value) saveDomain(value)
+            if (value) { saveDomain(value) }
           },
         },
       ],

--- a/Bonni/src/hooks/useAttentiveDomain.ts
+++ b/Bonni/src/hooks/useAttentiveDomain.ts
@@ -1,0 +1,93 @@
+/**
+ * Hook for managing the Attentive SDK domain setting.
+ * Owns persistence via AsyncStorage, SDK synchronisation, and
+ * the user-facing prompt so the screen stays free of that logic.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { Alert } from 'react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { updateDomain } from '@attentive-mobile/attentive-react-native-sdk'
+
+const DOMAIN_STORAGE_KEY = 'attentive_domain'
+const DEFAULT_DOMAIN = 'games'
+
+/** Shape returned by the hook. */
+export interface AttentiveDomainHook {
+  /** Currently active domain string. */
+  domain: string
+  /**
+   * Presents a native text prompt asking the user to enter a domain.
+   * On confirmation the domain is persisted and pushed to the SDK.
+   */
+  promptForDomain: () => void
+}
+
+/**
+ * Manages loading, persisting, and updating the Attentive domain.
+ *
+ * @returns The current domain string and a helper to prompt the user for a new one.
+ */
+export function useAttentiveDomain(): AttentiveDomainHook {
+  const [domain, setDomain] = useState<string>(DEFAULT_DOMAIN)
+
+  useEffect(() => {
+    loadDomain()
+  }, [])
+
+  /**
+   * Reads the persisted domain from AsyncStorage on mount.
+   */
+  const loadDomain = async () => {
+    try {
+      const saved = await AsyncStorage.getItem(DOMAIN_STORAGE_KEY)
+      if (saved !== null) setDomain(saved)
+    } catch (error) {
+      console.error('Error loading domain setting:', error)
+    }
+  }
+
+  /**
+   * Persists a new domain, updates local state, and notifies the SDK.
+   *
+   * @param newDomain - Raw string entered by the user.
+   * @throws Does not throw; surfaces errors via Alert.
+   */
+  const saveDomain = useCallback(async (newDomain: string) => {
+    const trimmed = newDomain.trim()
+    if (!trimmed) return
+    try {
+      setDomain(trimmed)
+      await AsyncStorage.setItem(DOMAIN_STORAGE_KEY, trimmed)
+      updateDomain(trimmed)
+      Alert.alert('Success', `Domain updated to: ${trimmed}`)
+    } catch (error) {
+      console.error('Error saving domain setting:', error)
+      Alert.alert('Error', 'Failed to save domain setting')
+    }
+  }, [])
+
+  /**
+   * Shows a native Alert.prompt pre-filled with the current domain.
+   * Calls saveDomain when the user confirms a non-empty value.
+   */
+  const promptForDomain = useCallback(() => {
+    Alert.prompt(
+      'Attentive Domain',
+      'Enter your domain name',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Save',
+          onPress: (value) => {
+            if (value) saveDomain(value)
+          },
+        },
+      ],
+      'plain-text',
+      domain,
+    )
+  }, [domain, saveDomain])
+
+  return { domain, promptForDomain }
+}

--- a/Bonni/src/hooks/useAttentiveDomain.ts
+++ b/Bonni/src/hooks/useAttentiveDomain.ts
@@ -2,12 +2,16 @@
  * Hook for managing the Attentive SDK domain setting.
  * Owns persistence via AsyncStorage, SDK synchronisation, and
  * the user-facing prompt so the screen stays free of that logic.
+ *
+ * On iOS  → prompt uses `Alert.prompt` natively (no extra UI needed).
+ * On Android → prompt opens a `TextPromptModal`; the caller MUST render
+ *              `DomainPromptModal` somewhere in the component tree.
  */
 
-import { useState, useEffect, useCallback } from 'react'
-import { Alert } from 'react-native'
+import React, { useState, useEffect, useCallback } from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { updateDomain } from '@attentive-mobile/attentive-react-native-sdk'
+import { useTextPrompt } from './useTextPrompt'
 
 const DOMAIN_STORAGE_KEY = 'attentive_domain'
 const DEFAULT_DOMAIN = 'games'
@@ -17,19 +21,28 @@ export interface AttentiveDomainHook {
   /** Currently active domain string. */
   domain: string
   /**
-   * Presents a native text prompt asking the user to enter a domain.
+   * Presents a text prompt asking the user to enter a domain.
+   * On iOS this uses `Alert.prompt`; on Android a modal overlay is used.
    * On confirmation the domain is persisted and pushed to the SDK.
    */
   promptForDomain: () => void
+  /**
+   * React element that must be mounted in the component tree.
+   * Always `null` on iOS. On Android this is the managed `TextPromptModal`.
+   * Place it at the root of the screen that calls `promptForDomain`.
+   */
+  DomainPromptModal: React.ReactElement | null
 }
 
 /**
  * Manages loading, persisting, and updating the Attentive domain.
  *
- * @returns The current domain string and a helper to prompt the user for a new one.
+ * @returns The current domain string, a helper to prompt the user for a new
+ *          one, and the modal element to render (Android only, null on iOS).
  */
 export function useAttentiveDomain(): AttentiveDomainHook {
   const [domain, setDomain] = useState<string>(DEFAULT_DOMAIN)
+  const { showPrompt, PromptModal: DomainPromptModal } = useTextPrompt()
 
   useEffect(() => {
     loadDomain()
@@ -41,7 +54,7 @@ export function useAttentiveDomain(): AttentiveDomainHook {
   const loadDomain = async () => {
     try {
       const saved = await AsyncStorage.getItem(DOMAIN_STORAGE_KEY)
-      if (saved !== null) setDomain(saved)
+      if (saved !== null) { setDomain(saved) }
     } catch (error) {
       console.error('Error loading domain setting:', error)
     }
@@ -55,7 +68,7 @@ export function useAttentiveDomain(): AttentiveDomainHook {
    */
   const saveDomain = useCallback(async (newDomain: string) => {
     const trimmed = newDomain.trim()
-    if (!trimmed) return
+    if (!trimmed) { return }
     try {
       setDomain(trimmed)
       await AsyncStorage.setItem(DOMAIN_STORAGE_KEY, trimmed)
@@ -66,26 +79,20 @@ export function useAttentiveDomain(): AttentiveDomainHook {
   }, [])
 
   /**
-   * Shows a native Alert.prompt pre-filled with the current domain.
-   * Calls saveDomain when the user confirms a non-empty value.
+   * Shows a text prompt pre-filled with the current domain.
+   * Delegates to `Alert.prompt` on iOS or the managed `TextPromptModal` on Android.
+   * Calls `saveDomain` when the user confirms a non-empty value.
    */
   const promptForDomain = useCallback(() => {
-    Alert.prompt(
-      'Switch Domain',
-      'Enter the new domain',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Save',
-          onPress: (value) => {
-            if (value) { saveDomain(value) }
-          },
-        },
-      ],
-      'plain-text',
-      domain,
-    )
-  }, [domain, saveDomain])
+    showPrompt({
+      title: 'Switch Domain',
+      message: 'Enter the new domain',
+      defaultValue: domain,
+      confirmText: 'Save',
+      cancelText: 'Cancel',
+      onConfirm: saveDomain,
+    })
+  }, [domain, saveDomain, showPrompt])
 
-  return { domain, promptForDomain }
+  return { domain, promptForDomain, DomainPromptModal }
 }

--- a/Bonni/src/hooks/useAttentiveDomain.ts
+++ b/Bonni/src/hooks/useAttentiveDomain.ts
@@ -54,7 +54,10 @@ export function useAttentiveDomain(): AttentiveDomainHook {
   const loadDomain = async () => {
     try {
       const saved = await AsyncStorage.getItem(DOMAIN_STORAGE_KEY)
-      if (saved !== null) { setDomain(saved) }
+      if (saved !== null) {
+        setDomain(saved)
+        updateDomain(saved)
+      }
     } catch (error) {
       console.error('Error loading domain setting:', error)
     }
@@ -70,9 +73,9 @@ export function useAttentiveDomain(): AttentiveDomainHook {
     const trimmed = newDomain.trim()
     if (!trimmed) { return }
     try {
-      setDomain(trimmed)
       await AsyncStorage.setItem(DOMAIN_STORAGE_KEY, trimmed)
       updateDomain(trimmed)
+      setDomain(trimmed)
     } catch (error) {
       console.error('Error saving domain setting:', error)
     }

--- a/Bonni/src/hooks/useTextPrompt.tsx
+++ b/Bonni/src/hooks/useTextPrompt.tsx
@@ -1,0 +1,179 @@
+/**
+ * Cross-platform text-input prompt hook.
+ *
+ * On iOS  → delegates directly to `Alert.prompt` (native OS dialog, no extra UI).
+ * On Android → manages a `TextPromptModal` overlay since `Alert.prompt` is iOS-only.
+ *
+ * Usage:
+ * ```tsx
+ * const { showPrompt, PromptModal } = useTextPrompt()
+ *
+ * // Render PromptModal once in your component tree (it is null on iOS)
+ * return (
+ *   <>
+ *     <YourScreen />
+ *     {PromptModal}
+ *   </>
+ * )
+ *
+ * // Trigger the prompt
+ * showPrompt({
+ *   title: 'Enter value',
+ *   defaultValue: current,
+ *   onConfirm: (val) => handleValue(val),
+ * })
+ * ```
+ */
+
+import React, { useCallback, useState } from 'react'
+import { Alert, Platform } from 'react-native'
+import { TextPromptModal } from '../components/TextPromptModal'
+
+/** Configuration passed to each individual prompt invocation. */
+export interface TextPromptConfig {
+  /** Dialog title. */
+  title: string
+  /** Optional subtitle displayed below the title. */
+  message?: string
+  /** Value pre-filled in the text input. */
+  defaultValue?: string
+  /** Ghost text shown when the input is empty. */
+  placeholder?: string
+  /** Label for the confirm button. Defaults to "Save". */
+  confirmText?: string
+  /** Label for the cancel button. Defaults to "Cancel". */
+  cancelText?: string
+  /**
+   * Called with the trimmed, non-empty input value when the user confirms.
+   * Empty strings after trimming are silently ignored.
+   */
+  onConfirm: (value: string) => void
+  /** Called when the user cancels or dismisses the dialog. */
+  onCancel?: () => void
+}
+
+/** Shape returned by the hook. */
+export interface TextPromptHook {
+  /**
+   * Imperatively shows a text prompt dialog.
+   * On iOS this calls `Alert.prompt`; on Android it opens a modal overlay.
+   *
+   * @param config - Title, message, default value, and callbacks.
+   */
+  showPrompt: (config: TextPromptConfig) => void
+  /**
+   * The React element that must be rendered somewhere in the component tree.
+   * Always `null` on iOS (no extra UI needed).
+   * On Android this is the `<TextPromptModal />` managed by the hook.
+   */
+  PromptModal: React.ReactElement | null
+}
+
+/** Internal state for the Android modal. */
+interface PromptState {
+  visible: boolean
+  title: string
+  message?: string
+  defaultValue: string
+  placeholder?: string
+  confirmText: string
+  cancelText: string
+  onConfirm: (value: string) => void
+  onCancel?: () => void
+}
+
+const INITIAL_STATE: PromptState = {
+  visible: false,
+  title: '',
+  defaultValue: '',
+  confirmText: 'Save',
+  cancelText: 'Cancel',
+  onConfirm: () => {},
+}
+
+/**
+ * Returns a cross-platform `showPrompt` function and a companion `PromptModal`
+ * element that must be mounted in the component tree (only relevant on Android).
+ */
+export function useTextPrompt(): TextPromptHook {
+  const [state, setState] = useState<PromptState>(INITIAL_STATE)
+
+  const dismiss = useCallback(() => {
+    setState((prev) => ({ ...prev, visible: false }))
+  }, [])
+
+  const handleConfirm = useCallback((value: string) => {
+    const trimmed = value.trim()
+    dismiss()
+    if (trimmed) state.onConfirm(trimmed)
+  }, [dismiss, state])
+
+  const handleCancel = useCallback(() => {
+    dismiss()
+    state.onCancel?.()
+  }, [dismiss, state])
+
+  const showPrompt = useCallback((config: TextPromptConfig) => {
+    const {
+      title,
+      message,
+      defaultValue = '',
+      placeholder,
+      confirmText = 'Save',
+      cancelText = 'Cancel',
+      onConfirm,
+      onCancel,
+    } = config
+
+    // iOS: use the native system dialog, no extra component needed
+    if (Platform.OS === 'ios') {
+      Alert.prompt(
+        title,
+        message,
+        [
+          { text: cancelText, style: 'cancel', onPress: onCancel },
+          {
+            text: confirmText,
+            onPress: (value) => {
+              const trimmed = (value ?? '').trim()
+              if (trimmed) onConfirm(trimmed)
+            },
+          },
+        ],
+        'plain-text',
+        defaultValue,
+      )
+      return
+    }
+
+    // Android: show the custom modal
+    setState({
+      visible: true,
+      title,
+      message,
+      defaultValue,
+      placeholder,
+      confirmText,
+      cancelText,
+      onConfirm,
+      onCancel,
+    })
+  }, [])
+
+  // PromptModal is only meaningful on Android; return null on iOS to keep renders clean
+  const PromptModal: React.ReactElement | null = Platform.OS === 'ios' ? null : (
+    <TextPromptModal
+      visible={state.visible}
+      title={state.title}
+      message={state.message}
+      defaultValue={state.defaultValue}
+      placeholder={state.placeholder}
+      confirmText={state.confirmText}
+      cancelText={state.cancelText}
+      onConfirm={handleConfirm}
+      onDismiss={handleCancel}
+    />
+  )
+
+  return { showPrompt, PromptModal }
+}

--- a/Bonni/src/screens/SettingsScreen.tsx
+++ b/Bonni/src/screens/SettingsScreen.tsx
@@ -24,6 +24,7 @@ import { getPrimaryButtonStyle, getPrimaryButtonTextStyle, getSecondaryButtonSty
 import { useAttentiveUser } from '../hooks/useAttentiveUser'
 import { useAttentiveActions } from '../hooks/useAttentiveActions'
 import { useAttentiveDomain } from '../hooks/useAttentiveDomain'
+import { useTextPrompt } from '../hooks/useTextPrompt'
 import {
   registerForPushNotifications,
   registerDeviceToken,
@@ -48,7 +49,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
   const [responseData, setResponseData] = useState<string>('')
   const [debuggerEnabled, setDebuggerEnabled] = useState<boolean>(true)
   const [displayAlerts, setDisplayAlerts] = useState<boolean>(true)
-  const { domain: attentiveDomain, promptForDomain } = useAttentiveDomain()
+  const { domain: attentiveDomain, promptForDomain, DomainPromptModal } = useAttentiveDomain()
+  const { showPrompt: showScreenPrompt, PromptModal: ScreenPromptModal } = useTextPrompt()
   const { identifyUser, clearUserIdentification } = useAttentiveUser()
   const { triggerAttentiveCreative, recordCustomAttentiveEvent } = useAttentiveActions()
 
@@ -127,38 +129,25 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
   }, [])
 
   const handleSwitchUser = useCallback(() => {
-    Alert.prompt(
-      'Switch Account / Log Out',
-      'Enter email or phone to identify, or cancel to log out',
-      [
-        {
-          text: 'Log Out',
-          style: 'destructive',
-          onPress: () => {
-            clearUserIdentification()
-            setCurrentUser('Guest')
-            Alert.alert('Success', 'Logged out successfully')
-          },
-        },
-        {
-          text: 'Cancel',
-          style: 'cancel',
-        },
-        {
-          text: 'Identify',
-          onPress: (value) => {
-            if (value) {
-              const isEmail = value.includes('@')
-              identifyUser(isEmail ? { email: value } : { phone: value })
-              setCurrentUser(value)
-              Alert.alert('Success', 'User identified!')
-            }
-          },
-        },
-      ],
-      'plain-text'
-    )
-  }, [identifyUser, clearUserIdentification])
+    showScreenPrompt({
+      title: 'Switch Account',
+      message: 'Enter email or phone to identify a new user',
+      placeholder: 'email or phone',
+      confirmText: 'Identify',
+      cancelText: 'Log Out',
+      onConfirm: (value) => {
+        const isEmail = value.includes('@')
+        identifyUser(isEmail ? { email: value } : { phone: value })
+        setCurrentUser(value)
+        Alert.alert('Success', 'User identified!')
+      },
+      onCancel: () => {
+        clearUserIdentification()
+        setCurrentUser('Guest')
+        Alert.alert('Success', 'Logged out successfully')
+      },
+    })
+  }, [identifyUser, clearUserIdentification, showScreenPrompt])
 
   const handleManageAddresses = useCallback(() => {
     // TODO: Implement address management
@@ -287,32 +276,22 @@ The SDK will handle the API request internally.`
   }, [displayAlerts])
 
   const handleIdentifyUser = useCallback(() => {
-    // Show prompt to enter user identifier (like iOS implementation)
-    Alert.prompt(
-      'Identify User',
-      'Enter email or phone to identify the user',
-      [
-        {
-          text: 'Cancel',
-          style: 'cancel',
-        },
-        {
-          text: 'Identify',
-          onPress: (value) => {
-            if (value) {
-              const isEmail = value.includes('@')
-              identifyUser(isEmail ? { email: value } : { phone: value })
-              setCurrentUser(value)
-              if (displayAlerts) {
-                Alert.alert('Success', `User identified: ${value}`)
-              }
-            }
-          },
-        },
-      ],
-      'plain-text'
-    )
-  }, [identifyUser, displayAlerts])
+    showScreenPrompt({
+      title: 'Identify User',
+      message: 'Enter email or phone to identify the user',
+      placeholder: 'email or phone',
+      confirmText: 'Identify',
+      cancelText: 'Cancel',
+      onConfirm: (value) => {
+        const isEmail = value.includes('@')
+        identifyUser(isEmail ? { email: value } : { phone: value })
+        setCurrentUser(value)
+        if (displayAlerts) {
+          Alert.alert('Success', `User identified: ${value}`)
+        }
+      },
+    })
+  }, [identifyUser, displayAlerts, showScreenPrompt])
 
   const handleClearUser = useCallback(() => {
     // Call SDK's clearUser method
@@ -623,6 +602,10 @@ The SDK will handle the API request internally.`
           </ScrollView>
         </View>
       </Modal>
+
+      {/* Cross-platform text prompt modals (null on iOS) */}
+      {DomainPromptModal}
+      {ScreenPromptModal}
 
     </>
   )

--- a/Bonni/src/screens/SettingsScreen.tsx
+++ b/Bonni/src/screens/SettingsScreen.tsx
@@ -23,8 +23,8 @@ import { Colors, Typography, Spacing, Layout, BorderRadius } from '../constants/
 import { getPrimaryButtonStyle, getPrimaryButtonTextStyle, getSecondaryButtonStyle, getSecondaryButtonTextStyle } from '../constants/buttonStyles'
 import { useAttentiveUser } from '../hooks/useAttentiveUser'
 import { useAttentiveActions } from '../hooks/useAttentiveActions'
+import { useAttentiveDomain } from '../hooks/useAttentiveDomain'
 import {
-  updateDomain,
   registerForPushNotifications,
   registerDeviceToken,
   handlePushOpened,
@@ -37,10 +37,7 @@ import PushNotificationIOS from '@react-native-community/push-notification-ios'
 const CONFIG_STORAGE_KEYS = {
   DEBUGGER_ENABLED: 'attentive_debugger_enabled',
   DISPLAY_ALERTS: 'attentive_display_alerts',
-  ATTENTIVE_DOMAIN: 'attentive_domain',
 }
-
-const ATTENTIVE_DOMAINS = ['vs', 'games', '76ers', 'belk']
 
 const SettingsScreen: React.FC<SettingsScreenProps> = () => {
   const [email, setEmail] = useState('')
@@ -51,8 +48,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
   const [responseData, setResponseData] = useState<string>('')
   const [debuggerEnabled, setDebuggerEnabled] = useState<boolean>(true)
   const [displayAlerts, setDisplayAlerts] = useState<boolean>(true)
-  const [attentiveDomain, setAttentiveDomain] = useState<string>('games')
-  const [domainPickerVisible, setDomainPickerVisible] = useState<boolean>(false)
+  const { domain: attentiveDomain, promptForDomain } = useAttentiveDomain()
   const { identifyUser, clearUserIdentification } = useAttentiveUser()
   const { triggerAttentiveCreative, recordCustomAttentiveEvent } = useAttentiveActions()
 
@@ -78,10 +74,9 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
    */
   const loadConfiguration = async () => {
     try {
-      const [debuggerValue, alertsValue, domainValue] = await Promise.all([
+      const [debuggerValue, alertsValue] = await Promise.all([
         AsyncStorage.getItem(CONFIG_STORAGE_KEYS.DEBUGGER_ENABLED),
         AsyncStorage.getItem(CONFIG_STORAGE_KEYS.DISPLAY_ALERTS),
-        AsyncStorage.getItem(CONFIG_STORAGE_KEYS.ATTENTIVE_DOMAIN),
       ])
 
       if (debuggerValue !== null) {
@@ -89,9 +84,6 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
       }
       if (alertsValue !== null) {
         setDisplayAlerts(alertsValue === 'true')
-      }
-      if (domainValue !== null) {
-        setAttentiveDomain(domainValue)
       }
     } catch (error) {
       console.error('Error loading configuration:', error)
@@ -131,23 +123,6 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
     } catch (error) {
       console.error('Error saving display alerts setting:', error)
       // Don't show alert here since alerts are being disabled
-    }
-  }, [])
-
-  /**
-   * Handle domain selection
-   * @param domain - Selected domain
-   */
-  const handleDomainSelect = useCallback(async (domain: string) => {
-    try {
-      setAttentiveDomain(domain)
-      await AsyncStorage.setItem(CONFIG_STORAGE_KEYS.ATTENTIVE_DOMAIN, domain)
-      updateDomain(domain)
-      setDomainPickerVisible(false)
-      Alert.alert('Success', `Domain updated to: ${domain}`)
-    } catch (error) {
-      console.error('Error saving domain setting:', error)
-      Alert.alert('Error', 'Failed to save domain setting')
     }
   }, [])
 
@@ -598,19 +573,16 @@ The SDK will handle the API request internally.`
             />
           </View>
 
-          {/* Domain Picker */}
-          <View style={styles.configRow}>
+          {/* Domain Input */}
+          <Pressable style={styles.configRow} onPress={promptForDomain}>
             <View style={styles.configLabelContainer}>
               <Text style={styles.configLabel}>Attentive Domain</Text>
             </View>
-            <Pressable
-              style={styles.domainPickerButton}
-              onPress={() => setDomainPickerVisible(true)}
-            >
+            <View style={styles.domainPickerButton}>
               <Text style={styles.domainPickerText}>{attentiveDomain}</Text>
               <Text style={styles.domainPickerArrow}>›</Text>
-            </Pressable>
-          </View>
+            </View>
+          </Pressable>
         </View>
 
         <View style={styles.divider} />
@@ -652,50 +624,6 @@ The SDK will handle the API request internally.`
         </View>
       </Modal>
 
-      {/* Domain Picker Modal */}
-      <Modal
-        visible={domainPickerVisible}
-        animationType="slide"
-        presentationStyle="formSheet"
-        onRequestClose={() => setDomainPickerVisible(false)}
-      >
-        <View style={styles.modalContainer}>
-          <View style={styles.modalHeader}>
-            <Text style={styles.modalTitle}>Select Domain</Text>
-            <TouchableOpacity
-              onPress={() => setDomainPickerVisible(false)}
-              style={styles.closeButton}
-            >
-              <Text style={styles.closeButtonText}>✕</Text>
-            </TouchableOpacity>
-          </View>
-          <ScrollView style={styles.modalContent}>
-            {ATTENTIVE_DOMAINS.map((domain) => (
-              <Pressable
-                key={domain}
-                style={({ pressed }) => [
-                  styles.domainOption,
-                  pressed && styles.domainOptionPressed,
-                  attentiveDomain === domain && styles.domainOptionSelected,
-                ]}
-                onPress={() => handleDomainSelect(domain)}
-              >
-                <Text
-                  style={[
-                    styles.domainOptionText,
-                    attentiveDomain === domain && styles.domainOptionTextSelected,
-                  ]}
-                >
-                  {domain}
-                </Text>
-                {attentiveDomain === domain && (
-                  <Text style={styles.domainOptionCheckmark}>✓</Text>
-                )}
-              </Pressable>
-            ))}
-          </ScrollView>
-        </View>
-      </Modal>
     </>
   )
 }
@@ -836,34 +764,6 @@ const styles = StyleSheet.create({
   domainPickerArrow: {
     fontSize: Typography.sizes.large,
     color: Colors.secondaryText,
-  },
-  domainOption: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: Spacing.base,
-    paddingHorizontal: Spacing.base,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.lightBackground,
-  },
-  domainOptionPressed: {
-    backgroundColor: Colors.lightBackground,
-  },
-  domainOptionSelected: {
-    backgroundColor: Colors.lightBackground,
-  },
-  domainOptionText: {
-    fontSize: Typography.sizes.medium,
-    color: Colors.black,
-  },
-  domainOptionTextSelected: {
-    fontWeight: Typography.weights.medium,
-    color: Colors.black,
-  },
-  domainOptionCheckmark: {
-    fontSize: Typography.sizes.medium,
-    color: Colors.black,
-    fontWeight: Typography.weights.bold,
   },
 })
 

--- a/Bonni/src/screens/SettingsScreen.tsx
+++ b/Bonni/src/screens/SettingsScreen.tsx
@@ -576,7 +576,7 @@ The SDK will handle the API request internally.`
           {/* Domain Input */}
           <Pressable style={styles.configRow} onPress={promptForDomain}>
             <View style={styles.configLabelContainer}>
-              <Text style={styles.configLabel}>Attentive Domain</Text>
+              <Text style={styles.configLabel}>Switch Domain</Text>
             </View>
             <View style={styles.domainPickerButton}>
               <Text style={styles.domainPickerText}>{attentiveDomain}</Text>


### PR DESCRIPTION
This pull request refactors how the Attentive domain is managed in the app, moving from a modal-based picker to a reusable hook that centralizes domain state, persistence, and SDK synchronization. The domain can now be changed via a native prompt, simplifying the UI and logic in `SettingsScreen`. The most important changes are grouped below:


https://github.com/user-attachments/assets/88538bfe-0587-443d-9535-a0962d591fa1


**Attentive Domain Management Refactor:**

* Added a new hook, `useAttentiveDomain`, which encapsulates loading, persisting, and updating the Attentive domain, as well as presenting a native prompt for user input. This replaces all direct domain state management and SDK calls in the screen component. (`Bonni/src/hooks/useAttentiveDomain.ts`)
* Updated exports in `index.ts` to include `useAttentiveDomain`, making the hook available throughout the app. (`Bonni/src/hooks/index.ts`)
* Refactored `SettingsScreen` to use the new `useAttentiveDomain` hook, removing all local state, handlers, and UI related to the domain picker modal. The domain is now changed via a simple pressable row that triggers the prompt. (`Bonni/src/screens/SettingsScreen.tsx`) [[1]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdR26-L27) [[2]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL40-L44) [[3]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL54-R51) [[4]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL81-L84) [[5]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL93-L95) [[6]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL137-L153) [[7]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL601-R585) [[8]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL655-L698) [[9]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL840-L867)

**UI Simplification:**

* Removed the domain picker modal and all associated styles, reducing UI complexity and code duplication. (`Bonni/src/screens/SettingsScreen.tsx`) [[1]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL655-L698) [[2]](diffhunk://#diff-2a06734e5d7d20c4bf11f633b03d8227ad9ebdaa3e57a4fedf19728719a9a1fdL840-L867)

These changes centralize Attentive domain logic, improve maintainability, and streamline the user experience for domain selection.