### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@attentive-mobile/attentive-react-native-sdk",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@attentive-mobile/attentive-react-native-sdk",
-      "version": "2.0.0-beta.9",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attentive-mobile/attentive-react-native-sdk",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.1",
   "description": "React Native Module for the Attentive SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary
- Promotes the React Native SDK from `2.0.0-beta.9` to the first stable 2.x release (`2.0.1`)
- Updates `package.json` and `package-lock.json`

## Next steps after merge
- Create a GitHub Release (which will also create the `2.0.1` tag)
- Publish to NPM
- Post in Eng Mobile SDK-releases channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)