### PR TITLE
chore: release 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@attentive-mobile/attentive-react-native-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@attentive-mobile/attentive-react-native-sdk",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attentive-mobile/attentive-react-native-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React Native Module for the Attentive SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary
- Bumps version to 2.0.2 (already published to npm and tagged on GitHub)
- Push to main was blocked by branch protection during `release-it`, so this PR lands the version bump commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)