### PR TITLE
feat: add updateUser (switch user) across iOS, Android, and the JS API

### DIFF
--- a/Bonni/package-lock.json
+++ b/Bonni/package-lock.json
@@ -61,7 +61,7 @@
         "@react-native-community/eslint-config": "^3.0.2",
         "@release-it/conventional-changelog": "^5.0.0",
         "@types/jest": "^28.1.2",
-        "@types/react": "~17.0.21",
+        "@types/react": "^18.2.6",
         "commitlint": "^17.0.2",
         "del-cli": "^5.0.0",
         "eslint": "^8.4.1",

--- a/Bonni/src/hooks/index.ts
+++ b/Bonni/src/hooks/index.ts
@@ -5,6 +5,8 @@
 
 export { useProductView, useAddToCart, usePurchase } from './useAttentiveEvents'
 export { useAttentiveUser } from './useAttentiveUser'
+export { useSwitchUser } from './useSwitchUser'
+export { useMarketingSubscriptions } from './useMarketingSubscriptions'
 export { useAttentiveActions } from './useAttentiveActions'
 export { useDisplayAlerts } from './useDisplayAlerts'
 export { useAttentiveDomain } from './useAttentiveDomain'

--- a/Bonni/src/hooks/useAttentiveUser.ts
+++ b/Bonni/src/hooks/useAttentiveUser.ts
@@ -31,4 +31,3 @@ export function useAttentiveUser() {
     clearUserIdentification,
   }
 }
-

--- a/Bonni/src/hooks/useSwitchUser.ts
+++ b/Bonni/src/hooks/useSwitchUser.ts
@@ -73,6 +73,8 @@ export function useSwitchUser(
         phone: trimmedPhone || undefined,
       })
       const label = [trimmedEmail, trimmedPhone].filter(Boolean).join(' / ')
+      setEmail('')
+      setPhone('')
       onSuccess?.(label)
     } catch (error) {
       onError?.(error instanceof Error ? error.message : 'User update failed')

--- a/Bonni/src/hooks/useSwitchUser.ts
+++ b/Bonni/src/hooks/useSwitchUser.ts
@@ -1,0 +1,95 @@
+/**
+ * Custom hook for the "switch user" (updateUser) flow.
+ * Keeps input state, validation, loading, and the SDK call out of the UI layer
+ * so SettingsScreen remains a thin view component.
+ */
+
+import { useState, useCallback } from 'react'
+import { updateUser } from '@attentive-mobile/attentive-react-native-sdk'
+import { validateEmail, validatePhone } from '../utils/validation'
+
+/**
+ * Shape returned by `useSwitchUser`.
+ */
+export interface UseSwitchUserResult {
+  email: string
+  phone: string
+  emailError: string | null
+  phoneError: string | null
+  isUpdating: boolean
+  setEmail: (value: string) => void
+  setPhone: (value: string) => void
+  clearErrors: () => void
+  handleUpdateUser: () => Promise<void>
+}
+
+/**
+ * Manages the state and SDK operation for the Switch User form.
+ *
+ * @param onSuccess - Called with a display label after the user is updated.
+ * @param onError - Called with an error message when validation or the update fails.
+ */
+export function useSwitchUser(
+  onSuccess?: (label: string) => void,
+  onError?: (message: string) => void
+): UseSwitchUserResult {
+  const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
+  const [emailError, setEmailError] = useState<string | null>(null)
+  const [phoneError, setPhoneError] = useState<string | null>(null)
+  const [isUpdating, setIsUpdating] = useState(false)
+
+  const clearErrors = useCallback(() => {
+    setEmailError(null)
+    setPhoneError(null)
+  }, [])
+
+  const handleUpdateUser = useCallback(async () => {
+    const trimmedEmail = email.trim()
+    const trimmedPhone = phone.trim()
+
+    if (!trimmedEmail && !trimmedPhone) {
+      const message = 'Enter an email or phone number'
+      setEmailError(message)
+      setPhoneError(null)
+      onError?.(message)
+      return
+    }
+
+    const nextEmailError = trimmedEmail ? validateEmail(trimmedEmail) : null
+    const nextPhoneError = trimmedPhone ? validatePhone(trimmedPhone) : null
+    setEmailError(nextEmailError)
+    setPhoneError(nextPhoneError)
+    const validationError = nextEmailError ?? nextPhoneError
+    if (validationError) {
+      onError?.(validationError)
+      return
+    }
+
+    setIsUpdating(true)
+    try {
+      await updateUser({
+        email: trimmedEmail || undefined,
+        phone: trimmedPhone || undefined,
+      })
+      const label = [trimmedEmail, trimmedPhone].filter(Boolean).join(' / ')
+      onSuccess?.(label)
+    } catch (error) {
+      onError?.(error instanceof Error ? error.message : 'User update failed')
+    } finally {
+      setIsUpdating(false)
+    }
+  }, [email, phone, onSuccess, onError])
+
+  return {
+    email,
+    phone,
+    emailError,
+    phoneError,
+    isUpdating,
+    setEmail,
+    setPhone,
+    clearErrors,
+    handleUpdateUser,
+  }
+}

--- a/Bonni/src/screens/SettingsScreen.tsx
+++ b/Bonni/src/screens/SettingsScreen.tsx
@@ -27,6 +27,7 @@ import { useAttentiveActions } from '../hooks/useAttentiveActions'
 import { useAttentiveDomain } from '../hooks/useAttentiveDomain'
 import { useTextPrompt } from '../hooks/useTextPrompt'
 import { useMarketingSubscriptions } from '../hooks/useMarketingSubscriptions'
+import { useSwitchUser } from '../hooks/useSwitchUser'
 import {
   registerForPushNotifications,
   registerDeviceToken,
@@ -46,6 +47,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
   const [deviceToken, setDeviceToken] = useState<string>('Not saved')
   const [currentUser, setCurrentUser] = useState<string>('Guest')
   const [responseModalVisible, setResponseModalVisible] = useState(false)
+  const [switchUserFormVisible, setSwitchUserFormVisible] = useState(false)
   const [responseData, setResponseData] = useState<string>('')
   const [debuggerEnabled, setDebuggerEnabled] = useState<boolean>(true)
   const [displayAlerts, setDisplayAlerts] = useState<boolean>(true)
@@ -78,6 +80,35 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
     handleOptInPhone,
     handleOptOutPhone,
   } = useMarketingSubscriptions(handleSubSuccess, handleSubError)
+  const handleSwitchUserSuccess = useCallback(
+    (label: string) => {
+      setCurrentUser(label)
+      setSwitchUserFormVisible(false)
+      if (displayAlerts) {
+        Alert.alert('Success', 'User update successful')
+      }
+    },
+    [displayAlerts]
+  )
+  const handleSwitchUserError = useCallback(
+    (message: string) => {
+      if (displayAlerts) {
+        Alert.alert('Error', message)
+      }
+    },
+    [displayAlerts]
+  )
+  const {
+    email: switchEmail,
+    phone: switchPhone,
+    emailError: switchEmailError,
+    phoneError: switchPhoneError,
+    isUpdating: isUpdatingUser,
+    setEmail: setSwitchEmail,
+    setPhone: setSwitchPhone,
+    clearErrors: clearSwitchUserErrors,
+    handleUpdateUser,
+  } = useSwitchUser(handleSwitchUserSuccess, handleSwitchUserError)
 
   // Load device token and configuration on mount
   useEffect(() => {
@@ -154,25 +185,22 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
   }, [])
 
   const handleSwitchUser = useCallback(() => {
-    showScreenPrompt({
-      title: 'Switch Account',
-      message: 'Enter email or phone to identify a new user',
-      placeholder: 'email or phone',
-      confirmText: 'Identify',
-      cancelText: 'Log Out',
-      onConfirm: (value) => {
-        const isEmail = value.includes('@')
-        identifyUser(isEmail ? { email: value } : { phone: value })
-        setCurrentUser(value)
-        Alert.alert('Success', 'User identified!')
-      },
-      onCancel: () => {
-        clearUserIdentification()
-        setCurrentUser('Guest')
-        Alert.alert('Success', 'Logged out successfully')
-      },
-    })
-  }, [identifyUser, clearUserIdentification, showScreenPrompt])
+    setSwitchUserFormVisible((visible) => !visible)
+    clearSwitchUserErrors()
+  }, [clearSwitchUserErrors])
+
+  const handleCancelSwitchUser = useCallback(() => {
+    setSwitchUserFormVisible(false)
+    clearSwitchUserErrors()
+  }, [clearSwitchUserErrors])
+
+  const handleLogOut = useCallback(() => {
+    clearUserIdentification()
+    setCurrentUser('Guest')
+    if (displayAlerts) {
+      Alert.alert('Success', 'Logged out successfully')
+    }
+  }, [clearUserIdentification, displayAlerts])
 
   const handleManageAddresses = useCallback(() => {
     // TODO: Implement address management
@@ -388,7 +416,85 @@ The SDK will handle the API request internally.`
             onPress={handleSwitchUser}
           >
             {({ pressed }) => (
-              <Text style={getPrimaryButtonTextStyle(pressed)}>Switch Account / Log Out</Text>
+              <Text style={getPrimaryButtonTextStyle(pressed)}>Switch User</Text>
+            )}
+          </Pressable>
+
+          {switchUserFormVisible ? (
+            <View style={styles.switchUserInlineForm}>
+              <TextInput
+                style={[styles.input, isUpdatingUser && styles.inputDisabled]}
+                placeholder="name@example.com"
+                value={switchEmail}
+                onChangeText={setSwitchEmail}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoCorrect={false}
+                editable={!isUpdatingUser}
+              />
+              {switchEmailError ? (
+                <Text style={styles.errorText}>{switchEmailError}</Text>
+              ) : null}
+
+              <TextInput
+                style={[styles.input, isUpdatingUser && styles.inputDisabled]}
+                placeholder="+15551234567"
+                value={switchPhone}
+                onChangeText={setSwitchPhone}
+                keyboardType="phone-pad"
+                autoCorrect={false}
+                editable={!isUpdatingUser}
+              />
+              {switchPhoneError ? (
+                <Text style={styles.errorText}>{switchPhoneError}</Text>
+              ) : null}
+
+              <View style={styles.switchUserActions}>
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.switchUserActionButton,
+                    getSecondaryButtonStyle(pressed),
+                    isUpdatingUser && styles.buttonDisabled,
+                  ]}
+                  onPress={handleCancelSwitchUser}
+                  disabled={isUpdatingUser}
+                >
+                  {({ pressed }) => (
+                    <Text style={getSecondaryButtonTextStyle(pressed)}>
+                      Cancel
+                    </Text>
+                  )}
+                </Pressable>
+
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.switchUserActionButton,
+                    getPrimaryButtonStyle(pressed),
+                    isUpdatingUser && styles.buttonDisabled,
+                  ]}
+                  onPress={handleUpdateUser}
+                  disabled={isUpdatingUser}
+                >
+                  {({ pressed }) =>
+                    isUpdatingUser ? (
+                      <ActivityIndicator size="small" color={Colors.white} />
+                    ) : (
+                      <Text style={getPrimaryButtonTextStyle(pressed)}>
+                        Update User
+                      </Text>
+                    )
+                  }
+                </Pressable>
+              </View>
+            </View>
+          ) : null}
+
+          <Pressable
+            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            onPress={handleLogOut}
+          >
+            {({ pressed }) => (
+              <Text style={getSecondaryButtonTextStyle(pressed)}>Log Out</Text>
             )}
           </Pressable>
 
@@ -945,6 +1051,17 @@ const styles = StyleSheet.create({
   inputDisabled: {
     opacity: 0.5,
     backgroundColor: Colors.lightBackground,
+  },
+  switchUserInlineForm: {
+    marginBottom: Spacing.md,
+  },
+  switchUserActions: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.sm,
+  },
+  switchUserActionButton: {
+    flex: 1,
   },
 })
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,14 @@ destroyCreative();
 
 
 ### Identify the current user
+
+Use `identify` to **add or enrich** information about the **current** user. As you gather identifiers (client user ID, email, phone, etc.), pass them to Attentive via `identify`. Each identifier is optional, and you can call `identify` repeatedly as you learn more about the user — **multiple calls combine the identifiers** rather than replacing them. The more identifiers you provide, the better the SDK functions.
+
+`identify` only enriches the *current* user; it does **not** switch users. When a **different** user logs in on the same device, use [`updateUser`](#switch-the-current-user-updateuser) instead — it clears the previous user's identifiers first.
+
 ```typescript
-// Before loading the creative or sending events, if you have any user identifiers, they will need to be registered. Each identifier is optional. It is okay to skip this step if you have no identifiers about the user yet.
+// If you have any user identifiers, register them before loading the creative or
+// sending events. Each identifier is optional — skip this step if you have none yet.
 const identifiers: UserIdentifiers = {
   phone: '+15556667777',
   email: 'some_email@gmailfake.com',
@@ -183,7 +189,7 @@ const identifiers: UserIdentifiers = {
 identify(identifiers);
 ```
 
-The more identifiers that are passed to `identify`, the better the SDK will function. Here is the list of possible identifiers:
+Here is the list of possible identifiers:
 | Identifier Name    | Type                  | Description                                                                                                             |
 | ------------------ | --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | Client User ID     | String                | Your unique identifier for the user. This should be consistent across the user's lifetime. For example, a database id.  |
@@ -192,6 +198,33 @@ The more identifiers that are passed to `identify`, the better the SDK will func
 | Shopify ID         | String                | The users's Shopify ID                                                                                                  |
 | Klaviyo ID         | String                | The users's Klaviyo ID                                                                                                  |
 | Custom Identifiers | Map<String,String>    | Key-value pairs of custom identifier names and values. The values should be unique to this user.                        |
+
+Because identifiers accumulate, you can register them as they become available — later calls add to the set rather than overwriting it:
+
+```typescript
+identify({ email: 'theusersemail@gmail.com' });
+identify({ phone: '+15556667777' });
+// The SDK now has both identifiers:
+//   email: 'theusersemail@gmail.com'
+//   phone: '+15556667777'
+```
+
+### Switch the current user (`updateUser`)
+
+Use `updateUser` to **switch to a different user** on the same device — for example, when one user logs out and a different user logs in. At least one of `email` or `phone` must be provided.
+
+Calling `updateUser` automatically clears the identifiers previously associated with the current user — including detaching any push token from them — and associates the app with the new identifier(s) you provide, so all subsequent events and messages are attributed to the new user. It returns a `Promise` that resolves on success and rejects with an error on failure.
+
+```typescript
+try {
+  // Switch to a different user on the same device
+  await updateUser({ email: 'newuser@example.com', phone: '+15559876543' });
+} catch (error) {
+  // Handle the failure (e.g. surface an error to the user)
+}
+```
+
+> Use `updateUser` only when switching to a different user. To add or enrich identifiers for the **current** user, prefer `identify` (shown above).
 
 ### Load the Creative
 
@@ -228,21 +261,6 @@ recordPurchaseEvent(purchase);
 ```
 
 The process is similar for the other events. See [eventTypes.tsx](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/src/eventTypes.tsx) for all events.
-
-### Update the current user when new identifiers are available
-
-```typescript
-// If new identifiers are available for the user, register them
-identify({email: 'theusersemail@gmail.com'});
-```
-
-```typescript
-identify({email: 'theusersemail@gmail.com'});
-identify({phone: '+15556667777'});
-// The SDK will have these two identifiers:
-//   email: 'theusersemail@gmail.com'
-//   phone: '+15556667777'
-```
 
 ### Push Notifications (iOS and Android)
 

--- a/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
+++ b/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
@@ -868,6 +868,14 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
         )
     }
 
+    /**
+     * Updates the current user's identifiers via the callback variant of
+     * [AttentiveSdk.updateUserWithCallback].
+     *
+     * @param email Optional email address for the user.
+     * @param phone Optional E.164 phone number for the user.
+     * @param promise Resolved with null on success; rejected with an error on failure.
+     */
     override fun updateUser(email: String?, phone: String?, promise: Promise) {
         Log.i(TAG, "👤 [AttentiveSDK] updateUser called")
 

--- a/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
+++ b/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
@@ -868,6 +868,52 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
         )
     }
 
+    override fun updateUser(email: String?, phone: String?, promise: Promise) {
+        Log.i(TAG, "👤 [AttentiveSDK] updateUser called")
+
+        AttentiveSdk.updateUserWithCallback(
+            email = email.orEmpty(),
+            phoneNumber = phone.orEmpty(),
+            callback = object : AttentiveSdk.AttentiveCallback {
+                override fun onSuccess() {
+                    Log.i(TAG, "✅ [AttentiveSDK] updateUser succeeded")
+                    UiThreadUtil.runOnUiThread { promise.resolve(null) }
+
+                    if (debugHelper.isDebuggingEnabled()) {
+                        val debugData = mutableMapOf(
+                            "email" to (email ?: "nil"),
+                            "phone" to (phone ?: "nil"),
+                            "status" to "success",
+                        )
+                        UiThreadUtil.runOnUiThread {
+                            debugHelper.showDebugInfo("Update User", debugData)
+                        }
+                    }
+                }
+
+                override fun onFailure(exception: Exception) {
+                    Log.e(TAG, "❌ [AttentiveSDK] updateUser failed: ${exception.message}", exception)
+
+                    val message = exception.message ?: "Unknown error"
+
+                    UiThreadUtil.runOnUiThread {
+                        promise.reject("UPDATE_USER_ERROR", message, exception)
+
+                        if (debugHelper.isDebuggingEnabled()) {
+                            val debugData = mapOf(
+                                "email" to (email ?: "nil"),
+                                "phone" to (phone ?: "nil"),
+                                "status" to "error",
+                                "error" to message,
+                            )
+                            debugHelper.showDebugInfo("Update User Error", debugData)
+                        }
+                    }
+                }
+            },
+        )
+    }
+
     // ==========================================================================
     // MARK: - NativeEventEmitter support
     // ==========================================================================

--- a/ios/AttentiveReactNativeSdk.mm
+++ b/ios/AttentiveReactNativeSdk.mm
@@ -447,6 +447,29 @@ customIdentifiers:(NSDictionary *)customIdentifiers {
     }];
 }
 
+- (void)updateUser:(NSString * _Nullable)email
+             phone:(NSString * _Nullable)phone
+           resolve:(RCTPromiseResolveBlock)resolve
+            reject:(RCTPromiseRejectBlock)reject {
+    NSString *normalizedEmail = (email && ![email isEqual:[NSNull null]] && email.length > 0) ? email : nil;
+    NSString *normalizedPhone = (phone && ![phone isEqual:[NSNull null]] && phone.length > 0) ? phone : nil;
+
+    if (!_sdk) {
+        reject(@"UPDATE_USER_ERROR", @"SDK not initialized", nil);
+        return;
+    }
+
+    [_sdk updateUserWithEmail:normalizedEmail
+                        phone:normalizedPhone
+                   completion:^(NSError * _Nullable error) {
+        if (error) {
+            reject(@"UPDATE_USER_ERROR", error.localizedDescription, error);
+        } else {
+            resolve(nil);
+        }
+    }];
+}
+
 - (void)triggerCreative:(NSString *)creativeId {
   dispatch_async(dispatch_get_main_queue(), ^{
     UIWindow *window = [[UIApplication sharedApplication] keyWindow];
@@ -485,4 +508,3 @@ customIdentifiers:(NSDictionary *)customIdentifiers {
 }
 
 @end
-

--- a/ios/Bridging/ATTNNativeSDK.swift
+++ b/ios/Bridging/ATTNNativeSDK.swift
@@ -616,6 +616,63 @@ struct DebugEvent {
     }
   }
 
+  @objc(updateUserWithEmail:phone:completion:)
+  public func updateUser(
+    email: String?,
+    phone: String?,
+    completion: @escaping (NSError?) -> Void
+  ) {
+    if debuggingEnabled {
+      showDebugInfo(event: "Update User Requested", data: [
+        "email": email ?? "nil",
+        "phone": phone ?? "nil"
+      ])
+    }
+
+    sdk.updateUser(email: email, phone: phone) { [weak self] _, _, response, error in
+      if let error = error {
+        completion(error as NSError)
+        if self?.debuggingEnabled == true {
+          self?.showDebugInfo(event: "Update User Failed", data: [
+            "email": email ?? "nil",
+            "phone": phone ?? "nil",
+            "status": "error",
+            "error": error.localizedDescription
+          ])
+        }
+        return
+      }
+
+      if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
+        completion(NSError(
+          domain: "com.attentive.sdk",
+          code: httpResponse.statusCode,
+          userInfo: [NSLocalizedDescriptionKey: "Update user failed with HTTP \(httpResponse.statusCode)"]
+        ))
+
+        if self?.debuggingEnabled == true {
+          self?.showDebugInfo(event: "Update User Failed", data: [
+            "email": email ?? "nil",
+            "phone": phone ?? "nil",
+            "status": "http_error",
+            "httpStatusCode": "\(httpResponse.statusCode)"
+          ])
+        }
+        return
+      }
+
+      completion(nil)
+
+      if self?.debuggingEnabled == true {
+        self?.showDebugInfo(event: "Update User Success", data: [
+          "email": email ?? "nil",
+          "phone": phone ?? "nil",
+          "status": "success"
+        ])
+      }
+    }
+  }
+
   // MARK: - Push Notification Helpers
 
   private func hexStringToData(_ hexString: String) -> Data? {

--- a/src/NativeAttentiveReactNativeSdk.ts
+++ b/src/NativeAttentiveReactNativeSdk.ts
@@ -20,6 +20,10 @@ export interface Spec extends TurboModule {
     customIdentifiers?: Object
   ) => void
   clearUser: () => void
+  updateUser: (
+    email: string | undefined,
+    phone: string | undefined
+  ) => Promise<void>
   recordAddToCartEvent: (
     items: Array<{
       productId: string

--- a/src/NativeAttentiveReactNativeSdk.ts
+++ b/src/NativeAttentiveReactNativeSdk.ts
@@ -20,6 +20,16 @@ export interface Spec extends TurboModule {
     customIdentifiers?: Object
   ) => void
   clearUser: () => void
+  /**
+   * Updates the current user's identifiers (email and/or phone).
+   *
+   * On iOS, delegates to the native ATTNSDK's updateUser; on Android, calls
+   * AttentiveSdk.updateUserWithCallback.
+   *
+   * @param email - Optional email address
+   * @param phone - Optional E.164 phone number
+   * @returns Promise that resolves on success or rejects with an error
+   */
   updateUser: (
     email: string | undefined,
     phone: string | undefined

--- a/src/eventTypes.tsx
+++ b/src/eventTypes.tsx
@@ -92,3 +92,8 @@ export interface MarketingSubscriptionParams {
   /** E.164 phone number to subscribe / unsubscribe */
   phone?: string;
 }
+
+export interface UpdateUserParams {
+  email?: string
+  phone?: string
+}

--- a/src/eventTypes.tsx
+++ b/src/eventTypes.tsx
@@ -93,7 +93,13 @@ export interface MarketingSubscriptionParams {
   phone?: string;
 }
 
+/**
+ * Parameters for the updateUser operation. Provide the email and/or
+ * E.164 phone number identifying the user to update.
+ */
 export interface UpdateUserParams {
-  email?: string
-  phone?: string
+  /** Email address to set for the user */
+  email?: string;
+  /** E.164 phone number to set for the user */
+  phone?: string;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import type {
   PushNotificationUserInfo,
   PushRegistrationResult,
   MarketingSubscriptionParams,
+  UpdateUserParams,
 } from './eventTypes'
 import NativeAttentiveReactNativeSdkModule, {
   type Spec,
@@ -532,6 +533,10 @@ function optOutMarketingSubscription(
   )
 }
 
+function updateUser(params: UpdateUserParams): Promise<void> {
+  return AttentiveReactNativeSdk.updateUser(params?.email, params?.phone)
+}
+
 export {
   initialize,
   triggerCreative,
@@ -559,6 +564,7 @@ export {
   // Marketing Subscription Methods
   optInMarketingSubscription,
   optOutMarketingSubscription,
+  updateUser,
 }
 
 export type {
@@ -576,4 +582,5 @@ export type {
   PushRegistrationResult,
   // Marketing Subscription Types
   MarketingSubscriptionParams,
+  UpdateUserParams,
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -533,6 +533,14 @@ function optOutMarketingSubscription(
   )
 }
 
+/**
+ * Updates the current user's identifiers (email and/or phone).
+ *
+ * Forwards the call to the native SDK on each platform.
+ *
+ * @param params - Object containing optional `email` and/or `phone`
+ * @returns Promise that resolves on success or rejects with an error
+ */
 function updateUser(params: UpdateUserParams): Promise<void> {
   return AttentiveReactNativeSdk.updateUser(params?.email, params?.phone)
 }


### PR DESCRIPTION
## Summary

Adds `updateUser` — switch the currently-identified user via email and/or phone — across every layer of the SDK, plus a demo in the Bonni example app.

- **JS/TS API** (`src/`): new `updateUser(params: UpdateUserParams): Promise<void>`, the `UpdateUserParams` type, and the TurboModule `Spec` method.
- **iOS** (`ios/`): Obj-C++ bridge method + Swift `updateUser` that normalizes email/phone, maps HTTP/errors to promise rejections, and emits debug events when debugging is enabled.
- **Android** (`android/`): Kotlin bridge routing to `AttentiveSdk.updateUserWithCallback`, resolving/rejecting the RN promise and emitting debug events only when debugging is enabled.
- **Bonni example** (`Bonni/`): a "Switch User" form backed by a dedicated `useSwitchUser` hook (input state, shared email/phone validation, loading flag, inline per-field errors), mirroring the existing `useMarketingSubscriptions` hook so the screen stays a thin view.
- **Docs**: a README "Switch the current user (`updateUser`)" section and a rewritten `identify` section that makes the enrich-vs-switch distinction explicit, plus JSDoc/KDoc on the new API.

## Behavior notes (surfaced by code review)

`updateUser` **switches** the identified user: it clears the previous user's identifiers (detaching their push token) and associates the new ones. Two native behaviors are worth knowing — both are inherited from the native SDKs and match how their own example apps behave (neither surfaces them):

- A **failed** `updateUser` leaves the user de-identified — native clears before the network call and does not restore on failure.
- It **requires a registered push token**; without one the call fails on both platforms.

The public JS wrapper intentionally delegates validation to native, matching every other wrapper in `src/index.tsx`. The one real gap — iOS native not enforcing "at least one identifier" (Android does) — is filed upstream as **MSDK-394**.

## Follow-ups

- **MSDK-391** — extract shared iOS bridge helpers (optIn/optOut/updateUser normalization + completion plumbing)
- **MSDK-392** — collapse duplicated debug-event blocks (Swift + Kotlin)
- **MSDK-394** — iOS native `updateUser` should enforce at-least-one-identifier (diverges from Android)

> Note: the Bonni app carries some **pre-existing** lint/type debt (e.g. `pushDebugHelpers.ts` `criticalAlert`, an unused import in `App.tsx`) unrelated to this PR; it may surface in CI independently of these changes.

## Test plan

- [ ] iOS: Switch User in Bonni with a valid email/phone (push token registered) → success
- [ ] Android: same
- [ ] Invalid email or phone → inline validation error, no SDK call
- [ ] Empty form → "Enter an email or phone number"
- [ ] Successful switch → reopening the form starts blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)
