### PR TITLE
ci: add Bonni to RN SDK CI (MSDK-379)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,14 @@ jobs:
       - run:
           name: Install Dependencies
           command: npm ci
+      # Build the SDK's lib/ output. Bonni (and any package-name consumer)
+      # resolves @attentive-mobile/attentive-react-native-sdk through the root
+      # package.json's main/types fields (lib/commonjs, lib/typescript), which
+      # only the `react-native` field skips in favor of src/. lib/ is gitignored,
+      # so without this step the Bonni typecheck/test jobs fail to resolve the SDK.
+      - run:
+          name: Build SDK
+          command: npm run build
       - save_cache:
           key: npm-v1-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,14 +55,6 @@ jobs:
       - run:
           name: Install Dependencies
           command: npm ci
-      # Build the SDK's lib/ output. Bonni (and any package-name consumer)
-      # resolves @attentive-mobile/attentive-react-native-sdk through the root
-      # package.json's main/types fields (lib/commonjs, lib/typescript), which
-      # only the `react-native` field skips in favor of src/. lib/ is gitignored,
-      # so without this step the Bonni typecheck/test jobs fail to resolve the SDK.
-      - run:
-          name: Build SDK
-          command: npm run build
       - save_cache:
           key: npm-v1-{{ checksum "package-lock.json" }}
           paths:
@@ -115,6 +107,14 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      # Build the SDK's lib/ output here rather than in checkout-and-setup so the
+      # SDK-only jobs (lint/typecheck/unit-test) don't wait on it -- they consume
+      # src/ via the package's `react-native` field. Bonni resolves the SDK by
+      # package name through main/types (lib/commonjs, lib/typescript), which is
+      # gitignored, so it must be built and persisted for the Bonni jobs below.
+      - run:
+          name: Build SDK
+          command: npm run build
       - restore_cache:
           keys:
             - npm-bonni-v1-{{ checksum "Bonni/package-lock.json" }}
@@ -130,6 +130,7 @@ jobs:
           root: .
           paths:
             - Bonni/node_modules
+            - lib
       - notify-slack-on-failure
 
   lint-bonni:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,62 @@ jobs:
           destination: coverage-report
       - notify-slack-on-failure
 
+  # Bonni (the sample app) has its own toolchain and node_modules. Install them
+  # once on top of the shared workspace, then hand them to the Bonni checks below.
+  # The SDK's example/ app is intentionally excluded (it has no tests, mirroring
+  # iOS which excludes its Example app).
+  setup-bonni:
+    executor: node-executor
+    steps:
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - npm-bonni-v1-{{ checksum "Bonni/package-lock.json" }}
+            - npm-bonni-v1-
+      - run:
+          name: Install Bonni Dependencies
+          command: npm --prefix Bonni ci
+      - save_cache:
+          key: npm-bonni-v1-{{ checksum "Bonni/package-lock.json" }}
+          paths:
+            - ~/.npm
+      - persist_to_workspace:
+          root: .
+          paths:
+            - Bonni/node_modules
+      - notify-slack-on-failure
+
+  lint-bonni:
+    executor: node-executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run ESLint (Bonni)
+          command: npm --prefix Bonni run lint
+      - notify-slack-on-failure
+
+  typecheck-bonni:
+    executor: node-executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run TypeScript type check (Bonni)
+          command: npm --prefix Bonni run typecheck
+      - notify-slack-on-failure
+
+  test-bonni:
+    executor: node-executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Unit Tests (Bonni)
+          command: npm --prefix Bonni test -- --ci
+      - notify-slack-on-failure
+
 # ========================
 # Workflows
 # ========================
@@ -118,3 +174,19 @@ workflows:
           context: *default_context
           requires:
             - checkout-and-setup
+      - setup-bonni:
+          context: *default_context
+          requires:
+            - checkout-and-setup
+      - lint-bonni:
+          context: *default_context
+          requires:
+            - setup-bonni
+      - typecheck-bonni:
+          context: *default_context
+          requires:
+            - setup-bonni
+      - test-bonni:
+          context: *default_context
+          requires:
+            - setup-bonni

--- a/Bonni/App.tsx
+++ b/Bonni/App.tsx
@@ -17,7 +17,6 @@ import {
   handlePushOpen,
   getPushAuthorizationStatus,
   registerForPushNotifications,
-  getInitialPushNotification,
   type AttentiveSdkConfiguration,
   type PushAuthorizationStatus,
   type PushNotificationUserInfo,

--- a/Bonni/__tests__/App.test.tsx
+++ b/Bonni/__tests__/App.test.tsx
@@ -7,7 +7,19 @@ import ReactTestRenderer from 'react-test-renderer'
 import App from '../App'
 
 test('renders correctly', async () => {
+  // App schedules deferred SDK work via setTimeout on mount. Use fake timers so
+  // those callbacks don't fire (and log) after the test finishes, then unmount to
+  // run effect cleanup. This keeps the smoke test focused on the initial render.
+  jest.useFakeTimers()
+
+  let renderer!: ReactTestRenderer.ReactTestRenderer
   await ReactTestRenderer.act(() => {
-    ReactTestRenderer.create(<App />)
+    renderer = ReactTestRenderer.create(<App />)
   })
+
+  await ReactTestRenderer.act(() => {
+    renderer.unmount()
+  })
+
+  jest.useRealTimers()
 })

--- a/Bonni/jest.config.js
+++ b/Bonni/jest.config.js
@@ -1,3 +1,17 @@
 module.exports = {
   preset: 'react-native',
+  // The react-native preset ignores node_modules when transforming. Several of
+  // our deps (e.g. @react-navigation/*) ship ES modules that Jest can't parse
+  // as-is, so we allowlist them through Babel here.
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@react-navigation|react-native-.*)/)',
+  ],
+  // The SDK lives at the repo root (Bonni depends on it via `file:..`) and would
+  // otherwise resolve the root's own react-native copy — a second, un-mocked
+  // instance that throws "__fbBatchedBridgeConfig is not set" on import. Pin every
+  // bare `react-native` import to Bonni's copy, which the preset has set up.
+  moduleNameMapper: {
+    '^react-native$': '<rootDir>/node_modules/react-native',
+  },
+  setupFiles: ['<rootDir>/jest.setup.js'],
 }

--- a/Bonni/jest.setup.js
+++ b/Bonni/jest.setup.js
@@ -30,17 +30,24 @@ const nativeModuleStub = () =>
 // bundles its own), so a NativeModules stub set here wouldn't reach it. Instead
 // mock the SDK's native-module file directly: it default-exports the native
 // module, and the public API (src/index.tsx) wraps that export. Stubbing it lets
-// the real JS wrappers run while the bridge calls become no-ops. Both import
-// styles used in Bonni — '../src' and '@attentive-mobile/attentive-react-native-sdk'
-// — resolve through this same file.
+// the real JS wrappers run while the bridge calls become no-ops.
+//
+// This only covers the '../src' import style (App.tsx). Imports by package name
+// — '@attentive-mobile/attentive-react-native-sdk', used by the screen hooks —
+// resolve through the file:.. symlink to the root package's main field
+// (lib/commonjs/index), whose own NativeAttentiveReactNativeSdk is a *different*
+// module this mock does not intercept. That path is covered instead by the
+// NativeModules stub below, which the built native-module file reads from.
 jest.mock('../src/NativeAttentiveReactNativeSdk', () => ({
   __esModule: true,
   default: nativeModuleStub(),
 }))
 
-// App.tsx builds `new NativeEventEmitter(NativeModules.AttentiveReactNativeSdk)`
-// against Bonni's own react-native copy, so stub that module here too (needs
-// addListener / removeListeners, which the proxy provides).
+// Covers two things: (1) App.tsx builds
+// `new NativeEventEmitter(NativeModules.AttentiveReactNativeSdk)` against Bonni's
+// own react-native copy (needs addListener / removeListeners, which the proxy
+// provides), and (2) the package-name import path above, whose built
+// NativeAttentiveReactNativeSdk reads the native module off NativeModules.
 NativeModules.AttentiveReactNativeSdk = nativeModuleStub()
 
 // AsyncStorage ships an official jest mock.

--- a/Bonni/jest.setup.js
+++ b/Bonni/jest.setup.js
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+
+/**
+ * Jest setup for Bonni.
+ *
+ * The full-app render test (`__tests__/App.test.tsx`) mounts <App />, which pulls
+ * in the Attentive SDK and a couple of native-only libraries. None of those native
+ * modules exist in the Jest environment, so we stub them here to keep the smoke
+ * test focused on the JS render path.
+ */
+
+import { NativeModules } from 'react-native'
+
+// A native-module stub: every property is a jest.fn returning a resolved Promise,
+// without masquerading as a thenable or exposing phantom symbol props.
+const nativeModuleStub = () =>
+  new Proxy(
+    {},
+    {
+      get: (_target, prop) => {
+        if (typeof prop !== 'string' || prop === 'then') {
+          return undefined
+        }
+        return jest.fn(() => Promise.resolve())
+      },
+    },
+  )
+
+// The SDK source resolves the *repo-root* copy of react-native (the host app
+// bundles its own), so a NativeModules stub set here wouldn't reach it. Instead
+// mock the SDK's native-module file directly: it default-exports the native
+// module, and the public API (src/index.tsx) wraps that export. Stubbing it lets
+// the real JS wrappers run while the bridge calls become no-ops. Both import
+// styles used in Bonni — '../src' and '@attentive-mobile/attentive-react-native-sdk'
+// — resolve through this same file.
+jest.mock('../src/NativeAttentiveReactNativeSdk', () => ({
+  __esModule: true,
+  default: nativeModuleStub(),
+}))
+
+// App.tsx builds `new NativeEventEmitter(NativeModules.AttentiveReactNativeSdk)`
+// against Bonni's own react-native copy, so stub that module here too (needs
+// addListener / removeListeners, which the proxy provides).
+NativeModules.AttentiveReactNativeSdk = nativeModuleStub()
+
+// AsyncStorage ships an official jest mock.
+jest.mock(
+  '@react-native-async-storage/async-storage',
+  () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+)
+
+// @react-native-community/push-notification-ios has no bundled jest mock; stub the
+// surface App.tsx uses so iOS push setup runs as no-ops during the render test.
+jest.mock('@react-native-community/push-notification-ios', () => ({
+  __esModule: true,
+  default: {
+    checkPermissions: jest.fn((cb) => cb && cb({})),
+    requestPermissions: jest.fn(() => Promise.resolve({})),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    getInitialNotification: jest.fn(() => Promise.resolve(null)),
+    addNotificationRequest: jest.fn(),
+    removeAllDeliveredNotifications: jest.fn(),
+    getDeliveredNotifications: jest.fn((cb) => cb && cb([])),
+    FetchResult: { NoData: 'UIBackgroundFetchResultNoData' },
+  },
+}))

--- a/Bonni/package.json
+++ b/Bonni/package.json
@@ -9,6 +9,7 @@
     "ios": "react-native run-ios",
     "gen-apk": "cd android && ./gradlew :app:assembleRelease --rerun-tasks && find app/build/outputs/apk -type f -name \"*.apk\" -print0 | xargs -0 ls -lt | head -n 5 && cd ..",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "start": "react-native start",
     "test": "jest",
     "pods": "cd ios && bundle exec pod install"

--- a/Bonni/src/utils/pushDebugHelpers.ts
+++ b/Bonni/src/utils/pushDebugHelpers.ts
@@ -25,7 +25,7 @@ export async function checkPushPermissions(): Promise<void> {
             console.log('   Sound:', permissions.sound ? '✅' : '❌')
             console.log('   Lock Screen:', permissions.lockScreen ? '✅' : '❌')
             console.log('   Notification Center:', permissions.notificationCenter ? '✅' : '❌')
-            console.log('   Critical Alert:', permissions.criticalAlert ? '✅' : '❌')
+            console.log('   Critical Alert:', permissions.critical ? '✅' : '❌')
             console.log('   Authorization Status:', permissions.authorizationStatus)
             
             resolve()


### PR DESCRIPTION
## Summary

Follow-up to [MSDK-378](https://attentivemobile.atlassian.net/browse/MSDK-378). Gates PRs on **Bonni**'s lint, typecheck, and tests in addition to the SDK checks — after fixing the pre-existing Bonni breakage that blocked it.

Jira: [MSDK-379](https://attentivemobile.atlassian.net/browse/MSDK-379)

## Fixes (pre-existing Bonni breakage)

- **Typecheck** — `pushDebugHelpers.ts` referenced `criticalAlert`, which doesn't exist on `PushNotificationPermissions`. Use the real field, `critical`.
- **Jest** — three layered failures, each masking the next:
  - Added `transformIgnorePatterns` for `@react-navigation/*` and other RN ESM deps (the documented ESM parse error).
  - Added a `moduleNameMapper` pinning bare `react-native` imports to Bonni's own copy. The SDK source otherwise resolves the **repo-root** `react-native` (a second, un-mocked instance → `__fbBatchedBridgeConfig is not set`).
  - Added `Bonni/jest.setup.js` stubbing the Attentive native module, AsyncStorage, and `push-notification-ios` so `<App />` renders.
  - Hardened `App.test.tsx` with fake timers + unmount so App's deferred `setTimeout` work doesn't emit "Cannot log after tests are done".
- **Lint** — removed an unused `getInitialPushNotification` import in `App.tsx` (a pre-existing lint **error**, not enumerated in the ticket but required for the `lint-bonni` gate). The `TODO(MSDK-352)` comment stays.

## CI

- New jobs in `.circleci/config.yml`: `setup-bonni` (installs Bonni's own `node_modules` with its own cache key, mirroring `checkout-and-setup`), then `lint-bonni`, `typecheck-bonni`, `test-bonni` — all running in `Bonni/` and wired into the `lint-typecheck-test` workflow.
- `example/` stays excluded (no tests; mirrors iOS excluding its Example app).
- Added a `typecheck` script to `Bonni/package.json` for a uniform `npm --prefix Bonni run …` command.

## Verification (against a fresh `npm ci`)

| Check | SDK | Bonni |
|---|---|---|
| lint | ✅ | ✅ |
| typecheck | ✅ | ✅ |
| tests | ✅ 37 | ✅ 32 |

`circleci config validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-378]: https://attentivemobile.atlassian.net/browse/MSDK-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MSDK-379]: https://attentivemobile.atlassian.net/browse/MSDK-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ