### PR TITLE
MSDK-401: Add AGENTS.md AI-agent integration guide (+ CLAUDE.md, build cleanups)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ lib/
 
 # test coverage
 coverage/
+
+# AI agent local config
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Do not invent a domain. Always initialize in `'debug'` mode for first-time integ
 
 Before editing anything, determine:
 
-1. **Is this a React Native app?** Confirm `react-native` is in the host `package.json` dependencies. The SDK requires **React Native >= 0.74**, Node >= 18, and (for iOS) Ruby >= 3.3 / CocoaPods ~> 1.16 / Xcode >= 15. For Android: Android SDK API 24+ and JDK 17.
+1. **Is this a React Native app?** Confirm `react-native` is in the host `package.json` dependencies. The SDK requires **React Native >= 0.74**, Node >= 18, and (for iOS) Ruby >= 3.3 / CocoaPods ~> 1.16 / Xcode >= 15. For Android: **Android SDK API 26+** and JDK 17. The wrapped Attentive Android SDK supports **API 26+** — it will build below 26 but its functionality **no-ops at runtime**, so if the host's `minSdkVersion` is below 26, warn the user that Attentive will silently do nothing for users on API 25 and below.
 2. **Bare React Native or Expo?** This SDK ships native modules, so it is **not compatible with Expo Go**. A plain (bare) React Native app is fine. An Expo app must use a development build / config plugin prebuild (i.e. it must have `ios/` and `android/` native directories). If the project is Expo *managed* with no native projects and the user won't prebuild, **stop and tell the user** — you cannot complete the native steps without the native projects.
 3. **Package manager**: detect from the lockfile (`package-lock.json` → npm, `yarn.lock` → yarn, `pnpm-lock.yaml` → pnpm). Use the matching install command.
 4. **iOS project**: confirm an `ios/` directory with a `Podfile` (and a `Podfile` referencing `use_native_modules!` / autolinking, which RN apps have by default).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,261 @@
+# Attentive React Native SDK — Agent Integration Guide
+
+This file is for AI coding agents (Claude Code, Cursor, Copilot, Codex, etc.) integrating the **Attentive React Native SDK** into a host React Native app. It is an alternative to reading the full `README.md` — it tells you exactly what to inspect in the client's codebase and what to write.
+
+If you are an agent and the user has asked you to "set up Attentive", "integrate the Attentive SDK", or similar, follow this guide top-to-bottom. Do not add features beyond the base case unless explicitly asked.
+
+---
+
+## Scope
+
+This guide covers **base integration only**:
+
+1. Install the npm package.
+2. **iOS** — run `pod install` and initialize the SDK from TypeScript (`initialize(config)`).
+3. **Android** — initialize the SDK in **native** Kotlin/Java code inside `MainApplication.onCreate()`.
+4. Verify the app builds on both platforms.
+
+Do **not**, in this pass:
+
+- Add `identify` / `clearUser` calls (the user will wire those at their own login/logout sites)
+- Add event recording (`recordPurchaseEvent`, `recordAddToCartEvent`, `recordProductViewEvent`, `recordCustomEvent`)
+- Add Creative rendering (`triggerCreative` / `destroyCreative`)
+- Add marketing subscription calls (`optInMarketingSubscription` / `optOutMarketingSubscription`)
+- Do **any** push-notification setup (no manifest changes, no `AppDelegate` push handlers, no FCM/`google-services.json`, no `@react-native-community/push-notification-ios`)
+
+If the user asks for more after the base case is working, refer them to `README.md` in the SDK repo. Step 5 emits the exact links.
+
+---
+
+## The one thing to get right: initialization differs per platform
+
+This SDK does **not** initialize the same way on both platforms. This is the most common integration mistake — read it before writing any code.
+
+- **iOS is initialized from TypeScript.** Calling `initialize(config)` forwards to the native iOS SDK.
+- **Android is NOT initialized from TypeScript.** On Android the TypeScript `initialize()` is an intentional **no-op** (it only wires the debug helper). The Android SDK **must** be initialized in native Kotlin/Java code in your `Application.onCreate()` via `AttentiveSdk.initialize(...)`. If you skip this, Android events fail silently.
+
+You will do **both** (Step 3a for iOS, Step 3b for Android). Calling `initialize(config)` from TypeScript unconditionally is fine — it is harmless on Android.
+
+---
+
+## Inputs you must collect from the user before writing code
+
+1. **Attentive domain** — a short string identifying their Attentive account (e.g. `myshop`). Ask:
+
+   > "Do you know your Attentive domain? It's the short identifier for your account (e.g. `myshop`)."
+
+   - If the user says **yes**, follow up with: "What is it?" Wait for their answer and use that exact string. Do not proceed until they've given you the domain.
+   - If the user says **no** (or doesn't know), insert `"YOUR_ATTENTIVE_DOMAIN"` as a placeholder and tell them to replace it before shipping.
+
+Do not invent a domain. Always initialize in `'debug'` mode for first-time integration; tell the user to switch to `'production'` for release builds.
+
+---
+
+## Step 1 — Inspect the client codebase
+
+Before editing anything, determine:
+
+1. **Is this a React Native app?** Confirm `react-native` is in the host `package.json` dependencies. The SDK requires **React Native >= 0.74**, Node >= 18, and (for iOS) Ruby >= 3.3 / CocoaPods ~> 1.16 / Xcode >= 15. For Android: Android SDK API 24+ and JDK 17.
+2. **Bare React Native or Expo?** This SDK ships native modules, so it is **not compatible with Expo Go**. A plain (bare) React Native app is fine. An Expo app must use a development build / config plugin prebuild (i.e. it must have `ios/` and `android/` native directories). If the project is Expo *managed* with no native projects and the user won't prebuild, **stop and tell the user** — you cannot complete the native steps without the native projects.
+3. **Package manager**: detect from the lockfile (`package-lock.json` → npm, `yarn.lock` → yarn, `pnpm-lock.yaml` → pnpm). Use the matching install command.
+4. **iOS project**: confirm an `ios/` directory with a `Podfile` (and a `Podfile` referencing `use_native_modules!` / autolinking, which RN apps have by default).
+5. **Android project**: locate the host `MainApplication` file — `android/app/src/main/java/<package-path>/MainApplication.kt` (or `.java`). Note whether it's **Kotlin or Java** and match it. Locate `AndroidManifest.xml` too (not edited in the base case).
+6. **Architecture**: the SDK is autolinked and works on both the New Architecture (TurboModule) and the old architecture (it falls back automatically). **Do not** toggle the New Architecture flag or bump the host's React Native version.
+
+---
+
+## Step 2 — Install the package
+
+### 2a. Install via the host's package manager
+
+Unlike a pinned native dependency, npm installs the latest published version by default — you do **not** need to look up a version number.
+
+```bash
+# npm
+npm install @attentive-mobile/attentive-react-native-sdk
+
+# yarn
+yarn add @attentive-mobile/attentive-react-native-sdk
+
+# pnpm
+pnpm add @attentive-mobile/attentive-react-native-sdk
+```
+
+If the user needs a specific version, append `@<version>` — otherwise let it resolve to latest.
+
+### 2b. iOS — install pods
+
+The native module is autolinked; you do **not** edit the `Podfile` by hand. From the host app root:
+
+```bash
+cd ios && bundle exec pod install   # if the project uses Bundler (a Gemfile is present)
+# or
+npx pod-install
+```
+
+### 2c. Rebuild required
+
+This adds native code, so a Metro reload is not enough — the app must be rebuilt (Step 4). Do not move on to Step 3 thinking a JS-only refresh will pick it up.
+
+---
+
+## Step 3 — Initialize the SDK (do BOTH 3a and 3b)
+
+### 3a. iOS — initialize from TypeScript
+
+In the app's root component (e.g. `App.tsx`), initialize once at startup inside a `useEffect`. Match the host's existing import style.
+
+```typescript
+import { useEffect } from 'react'
+import {
+  initialize,
+  type AttentiveSdkConfiguration,
+} from '@attentive-mobile/attentive-react-native-sdk'
+
+function App() {
+  useEffect(() => {
+    const config: AttentiveSdkConfiguration = {
+      attentiveDomain: 'YOUR_ATTENTIVE_DOMAIN',
+      mode: 'debug', // switch to 'production' for release builds
+    }
+    initialize(config)
+  }, [])
+
+  // ...rest of the app
+}
+```
+
+If the host already has a root `useEffect` for app startup, add `initialize(config)` there rather than introducing a second effect. Place it as early as possible in the startup path. This call is a no-op on Android (see 3b), so it does not need to be guarded with `Platform.OS === 'ios'`.
+
+### 3b. Android — initialize in native code (REQUIRED)
+
+On Android the SDK must be initialized in `Application.onCreate()`, **not** from TypeScript. Two reasons:
+
+1. The SDK registers lifecycle observers (e.g. `AppLaunchTracker` on the `ProcessLifecycleOwner`) that must be in place **before** the React Native bridge is ready, or early app-launch events are missed.
+2. `lifecycle.addObserver()` must run on the main thread; `Application.onCreate()` is guaranteed by Android to run on the main thread, so no threading wrapper is needed.
+
+Every React Native app has a `MainApplication` class — edit the existing one. Add the init **after** `super.onCreate()` (and after any logging/crash-reporter init the app already has). Match the file's language.
+
+**Kotlin (`MainApplication.kt`):**
+
+```kotlin
+import com.attentive.androidsdk.AttentiveConfig
+import com.attentive.androidsdk.AttentiveSdk
+
+class MainApplication : Application(), ReactApplication {
+
+  override fun onCreate() {
+    super.onCreate()
+    // ...existing SoLoader / New Architecture / other setup stays here...
+
+    val config = AttentiveConfig.Builder()
+      .applicationContext(this)
+      .domain("YOUR_ATTENTIVE_DOMAIN")
+      .mode(AttentiveConfig.Mode.DEBUG) // Mode.PRODUCTION for release builds
+      .build()
+
+    // Application.onCreate() runs on the main thread, which the SDK requires.
+    AttentiveSdk.initialize(config)
+  }
+}
+```
+
+**Java (`MainApplication.java`):**
+
+```java
+import com.attentive.androidsdk.AttentiveConfig;
+import com.attentive.androidsdk.AttentiveSdk;
+
+@Override
+public void onCreate() {
+  super.onCreate();
+  // ...existing setup stays here...
+
+  AttentiveConfig config = new AttentiveConfig.Builder()
+      .applicationContext(this)
+      .domain("YOUR_ATTENTIVE_DOMAIN")
+      .mode(AttentiveConfig.Mode.DEBUG) // Mode.PRODUCTION for release builds
+      .build();
+
+  AttentiveSdk.initialize(config);
+}
+```
+
+> Do **not** call `AttentiveSdk.initialize()` from a background thread or a non-main coroutine dispatcher — AndroidX will throw an `IllegalStateException`. `onCreate()` is correct.
+>
+> The `notificationIconId(...)` / `skipFatigueOnCreatives(...)` / `logLevel(...)` builder options are not needed for base integration — `notificationIconId` is push-related. Leave them out for now.
+
+---
+
+## Step 4 — Verify the build
+
+Build the app on each platform the user targets. A passing build is the verification — do not run the app on a device/simulator unless asked.
+
+**iOS:**
+
+```bash
+npx react-native run-ios   # or build in Xcode (⌘B)
+```
+
+- If you see the linking error `The package 'attentive-react-native-sdk' doesn't seem to be linked`, it means `pod install` didn't run or the app wasn't rebuilt (or it's running under Expo Go). Re-run Step 2b and rebuild.
+
+**Android:**
+
+```bash
+npx react-native run-android   # or build in Android Studio
+```
+
+- Confirm the native init ran and there are no warnings like `recordX failed — SDK may not be initialized` in logcat:
+
+  ```bash
+  adb logcat | grep -i attentive
+  ```
+
+  If you see that warning, the `AttentiveSdk.initialize()` call from Step 3b is missing or didn't run before an event fired — re-check `MainApplication.onCreate()`.
+
+---
+
+## Step 5 — Hand off
+
+1. Tell the user:
+   - Replace `"YOUR_ATTENTIVE_DOMAIN"` with their real domain in **both** places (TypeScript config and `MainApplication`) if a placeholder was used.
+   - Switch `'debug'` / `Mode.DEBUG` to `'production'` / `Mode.PRODUCTION` for release builds.
+
+2. Then **emit the following block to the user, verbatim**, including every `[text](url)` link exactly as written. Do not rewrite, summarize, paraphrase, drop URLs, or convert links to plain titles. The user's terminal renders Markdown; without the `(url)` part, the links are dead.
+
+   ```
+   The base integration is in. For everything this guide intentionally skipped, see the [SDK README](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md):
+
+   - [Identify the current user](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md#identify-the-current-user) — call at login or whenever you learn the user's email, phone, `clientUserId`, Shopify ID, Klaviyo ID, or custom identifiers.
+   - [Record user events](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md#record-user-events) — `recordPurchaseEvent`, `recordAddToCartEvent`, `recordProductViewEvent`, `recordCustomEvent`, plus the `Item` / `Purchase` / `ProductView` / `AddToCart` types.
+   - [Show a Creative](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md#load-the-creative) and [destroy it](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md#destroy-the-creative) — in-app messages rendered over your app.
+   - [Push notifications (iOS & Android)](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md#push-notifications-ios-and-android) and [App events on Android](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md#app-events-on-android) — the iOS `AppDelegate` hook, Android manifest/FCM setup, and token registration.
+   - [Debugging features](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md#debugging-features) — `enableDebugger`, debug overlays, and log export.
+   - `clearUser`, `updateDomain`, and marketing subscription helpers (`optInMarketingSubscription` / `optOutMarketingSubscription`) are exported from the package — see the API surface in [src/index.tsx](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/src/index.tsx) and the types in [src/eventTypes.tsx](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/src/eventTypes.tsx).
+   ```
+
+Do not run the app on a device or simulator unless asked.
+
+---
+
+## Things NOT to do
+
+- Do not add `identify()`, `clearUser()`, any `recordXEvent()`, `triggerCreative()`/`destroyCreative()`, or marketing-subscription calls.
+- Do not do any push setup — no `POST_NOTIFICATIONS` in the manifest, no `MainActivity.onNewIntent` override, no `AppDelegate` push handlers, no FCM / `google-services.json`, no `@react-native-community/push-notification-ios`.
+- Do not call `AttentiveSdk.initialize()` outside `Application.onCreate()` or on a background thread.
+- Do not try to initialize Android from TypeScript — the JS `initialize()` is a no-op there.
+- Do not toggle the New Architecture, or bump the host's React Native, Gradle, AGP, Kotlin, or CocoaPods versions.
+- Do not introduce state-management or DI libraries to wire initialization — a plain call in `useEffect` (iOS) and `onCreate` (Android) is correct.
+- Do not write tests for the integration unless asked.
+
+---
+
+## Reference
+
+- Full documentation: https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md
+- Sample app: `Bonni/` in the SDK repo — a working reference integration for both platforms.
+- Push notification guides: `docs/PUSH_NOTIFICATIONS_INTEGRATION.md` and `docs/PUSH_NOTIFICATIONS_SETUP.md`.
+
+### What this guide intentionally skipped
+
+The base-integration guide does not wire up identify/clearUser, event recording, Creatives, marketing subscriptions, runtime domain changes, or any push setup. Step 5 already emits the linked README pointers for these to the user — see that step for the canonical block.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+Guidance for AI coding agents working **on** the Attentive React Native SDK itself (this repo). If you are instead helping a client integrate the SDK into their app, use [`AGENTS.md`](./AGENTS.md) — that is the consumer-facing guide. Do not conflate the two.
+
+## What this package is
+
+`@attentive-mobile/attentive-react-native-sdk` is a React Native wrapper around Attentive's native iOS and Android SDKs. It exposes a TypeScript API (creatives, events, identify, push, marketing subscriptions) and bridges each call to the corresponding native SDK.
+
+## Repository layout
+
+| Path | What's there |
+|---|---|
+| `src/index.tsx` | Public TypeScript API — the thin layer consumers import. Each function forwards to the native module. |
+| `src/NativeAttentiveReactNativeSdk.ts` | The TurboModule **codegen spec** (`interface Spec extends TurboModule`). Adding/changing a native method starts here. Includes the old-architecture `NativeModules` fallback. |
+| `src/eventTypes.tsx` | Public types (`AttentiveSdkConfiguration`, `UserIdentifiers`, `Item`, `Purchase`, etc.). |
+| `ios/` | Swift bridging layer (e.g. `AttentiveSDKManager`, `ATTNNativeSDK`) over `attentive-ios-sdk`. |
+| `android/src/main/kotlin/com/attentivereactnativesdk/` | Kotlin TurboModule (`AttentiveReactNativeSdkModule.kt`, `AttentiveReactNativeSdkPackage.kt`, push + debug helpers) over `attentive-android-sdk`. |
+| `Bonni/` | The example / test-harness app. Use it to exercise changes on a real app on both platforms. |
+| `lib/` | Build output from `react-native-builder-bob` — generated, do not edit by hand. |
+| `docs/` | `PUSH_NOTIFICATIONS_INTEGRATION.md`, `PUSH_NOTIFICATIONS_SETUP.md`. |
+| Root docs | `README.md` (consumer reference), `DEBUGGING.md`, `MIGRATION_GUIDE.md`, `AGENTS.md` (consumer agent guide). |
+| `attentive-react-native-sdk.podspec` | iOS pod definition; pins the native `attentive-ios-sdk` dependency. |
+
+## Architecture
+
+- The native module is a **TurboModule** generated via codegen (`codegenConfig` in `package.json`: spec name `AttentiveReactNativeSdkSpec`, Android package `com.attentivereactnativesdk`). It also works on the old architecture through the `NativeModules` fallback in `NativeAttentiveReactNativeSdk.ts`.
+- Bridge data crosses as flat scalars (codegen limitation): e.g. on event payloads `price`/`currency` are flat fields on each item and `orderId` is a flat arg, not nested objects. Keep new native method signatures flat-friendly.
+
+## Critical invariant — initialization is asymmetric
+
+**iOS initializes from TypeScript; Android initializes in native code.** The TypeScript `initialize()` (`src/index.tsx`) forwards to the native module, but the Android implementation's `initialize()` is an **intentional no-op** (`AttentiveReactNativeSdkModule.kt`, ~lines 59–98) — it only wires the debug helper. On Android the SDK must be initialized by the host app in `Application.onCreate()` via `AttentiveSdk.initialize(AttentiveConfig…)`, because lifecycle observers must register on the main thread before the RN bridge is ready. `Bonni/android/app/src/main/java/com/bonni/MainApplication.kt` is the canonical example.
+
+Do not "fix" the Android `initialize()` to actually initialize the SDK without understanding this — it would break main-thread / early-lifecycle guarantees. Keep `README.md`, `AGENTS.md`, and the `src/index.tsx` JSDoc consistent with this behavior whenever you touch initialization.
+
+## Common commands
+
+```bash
+npm run build      # bundle with react-native-builder-bob -> lib/
+npm test           # jest (tests live under src/)
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint over src/**/*.{js,ts,tsx}
+```
+
+Code style is enforced by Prettier (single quotes, no semicolons, 2-space, trailing commas es5) via the ESLint config in `package.json` — match it.
+
+## Testing changes
+
+Use the `Bonni/` app to validate end-to-end on a device/simulator. For Android changes, remember the native init lives in Bonni's `MainApplication.kt`; for iOS, init flows from Bonni's `App.tsx`. CI runs build, typecheck, lint, and tests for the SDK and Bonni — make sure those pass locally before pushing.
+
+## Linking the SDK from a local checkout (testing / contributors)
+
+This is for **testing the SDK by linking this checkout into a separate host app** (e.g. a throwaway RN app, or a monorepo). It is **not** something published-package consumers need — so it lives here, not in `AGENTS.md`. Real clients install `@attentive-mobile/attentive-react-native-sdk` from npm and never hit any of this.
+
+Install the local checkout into the host app via a path dependency:
+
+```bash
+npm install file:../attentive-react-native-sdk    # adjust the relative path
+```
+
+**Why a Metro tweak is then required.** `package.json` points the `react-native` and `source` fields at `src/index` (TypeScript source), so when the host app bundles, Metro pulls in this repo's **source** and crawls its `node_modules` — which contains a version-skewed `react-native@0.75.5` (a devDependency, see `package.json`). Two copies of `react-native` in the graph cause a **Metro Haste module-name collision**, and the SDK can bind against the wrong React Native. (npm consumers never see this: the published tarball excludes `node_modules` — see the `files` array in `package.json`.)
+
+Fix it in the **host app's** `metro.config.js`: watch this folder, block its nested `node_modules`, and funnel shared deps to the host app's copy.
+
+```js
+const path = require('path');
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+
+// Adjust to wherever this SDK checkout lives relative to the host app.
+const sdkRoot = path.resolve(__dirname, '../attentive-react-native-sdk');
+const escaped = sdkRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const defaultConfig = getDefaultConfig(__dirname);
+
+module.exports = mergeConfig(defaultConfig, {
+  watchFolders: [sdkRoot],
+  resolver: {
+    blockList: [
+      defaultConfig.resolver.blockList,
+      new RegExp(`^${escaped}/node_modules/.*$`),
+    ].filter(Boolean),
+    extraNodeModules: new Proxy(
+      {},
+      {
+        get: (_t, name) =>
+          typeof name === 'string' ? path.join(__dirname, 'node_modules', name) : undefined,
+      }
+    ),
+  },
+});
+```
+
+Revert the host app's `metro.config.js` to its default once it consumes the published npm package instead of the local link.
+
+## When adding or changing a native method
+
+1. Update the spec in `src/NativeAttentiveReactNativeSdk.ts`.
+2. Add the JS wrapper + types in `src/index.tsx` / `src/eventTypes.tsx`.
+3. Implement on both platforms: `android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt` and the `ios/` bridging layer.
+4. Rebuild (`npm run build`) and exercise it in `Bonni/`.
+5. If it changes the consumer integration steps, update `README.md` **and** `AGENTS.md`.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Run `npm install @attentive-mobile/attentive-react-native-sdk` from your app's r
 
 ## Setup with an AI coding agent
 
+> [!WARNING]
+> **Experimental.** Agent-assisted setup is a new, experimental feature. The [`AGENTS.md`](./AGENTS.md) guide and this flow may change, and results can vary by agent and project. Review whatever the agent changes before committing, and fall back to the manual steps below if anything looks off.
+
 If you use Claude Code, Cursor, Copilot, Codex, or another AI coding agent, you can have the agent walk you through setup. Point it at [`AGENTS.md`](./AGENTS.md) in this repo — it's a step-by-step integration guide written for agents that handles the npm install, iOS `pod install` + TypeScript `initialize()`, and the **native** Android initialization in `MainApplication.onCreate()`.
 
 **To trigger the flow**, open your project in your agent of choice and paste:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,18 @@ This project uses **npm** as the preferred package manager for consistency and a
 
 Run `npm install @attentive-mobile/attentive-react-native-sdk` from your app's root directory.
 
+## Setup with an AI coding agent
+
+If you use Claude Code, Cursor, Copilot, Codex, or another AI coding agent, you can have the agent walk you through setup. Point it at [`AGENTS.md`](./AGENTS.md) in this repo — it's a step-by-step integration guide written for agents that handles the npm install, iOS `pod install` + TypeScript `initialize()`, and the **native** Android initialization in `MainApplication.onCreate()`.
+
+**To trigger the flow**, open your project in your agent of choice and paste:
+
+> Integrate the Attentive React Native SDK into this app. Follow the guide at https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/AGENTS.md top-to-bottom and ask me any questions it tells you to ask before writing code.
+
+The agent flow intentionally stops at base integration. It does **not** wire up identify/clearUser, event recording, Creatives, marketing subscriptions, or push notifications — see the sections below for those.
+
 ## Usage
-See the [Example Project](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/example)
+See the [Bonni example app](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/Bonni)
 for a sample of how the Attentive React Native SDK is used.
 
 __*** NOTE: Please refrain from using any private or undocumented classes or methods as they may change between releases. ***__

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,23 +57,11 @@ android {
 
 }
 
-//Properties ghProperties = new Properties()
-//File ghPropertiesFile = file("github.properties")
-//if (!ghPropertiesFile.exists()) {
-//  throw new GradleException('Could not find github.properties file.')
-//}
-//ghProperties.load(ghPropertiesFile.newDataInputStream())
-
 repositories {
+  // attentive-android-sdk is published to Maven Central (it's the latest release there),
+  // so mavenCentral() resolves it with no credentials. No GitHub Packages repo needed.
   mavenCentral()
   google()
-  maven {
-    url = uri("https://maven.pkg.github.com/attentive-mobile/attentive-android-sdk")
-    credentials {
-//      username = ghProperties.getProperty('gpr.user')
-//      password = ghProperties.getProperty('gpr.key')
-    }
-  }
 }
 
 

--- a/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
+++ b/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
@@ -451,7 +451,7 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
                 "success" to true,
                 "token" to "${token.take(16)}...",
                 "platform" to "Android",
-                "sdk_version" to "2.1.1",
+                "sdk_version" to "2.1.9",
                 "registration_triggered" to true
             )
 
@@ -609,7 +609,7 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
                 debugData["event_type"] = "push_open"
                 debugData["platform"] = "Android"
                 debugData["payload_keys"] = payload.keys.joinToString(", ")
-                debugData["sdk_version"] = "2.1.1"
+                debugData["sdk_version"] = "2.1.9"
                 debugHelper.showDebugInfo("Push Open Event", debugData)
             }
         } catch (e: Exception) {
@@ -675,7 +675,7 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
                 debugData["event_type"] = "foreground_push"
                 debugData["platform"] = "Android"
                 debugData["payload_keys"] = payload.keys.joinToString(", ")
-                debugData["sdk_version"] = "2.1.1"
+                debugData["sdk_version"] = "2.1.9"
                 debugHelper.showDebugInfo("Foreground Push Event", debugData)
             }
         } catch (e: Exception) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,10 +41,16 @@ const AttentiveReactNativeSdk = (
 
 /**
  * Initialize the Attentive SDK with the provided configuration.
- * This is the only supported entry point: the app (e.g. Bonni) must call this from TypeScript
- * once at startup; the call is forwarded to the native module on each platform (iOS/Android),
- * which then initializes the platform Attentive SDK. Native code must not initialize the SDK
- * on its own (e.g. in Application onCreate or AppDelegate).
+ *
+ * Initialization is asymmetric across platforms:
+ * - **iOS:** call this once at startup (e.g. in the root component's `useEffect`). The call is
+ *   forwarded to the native module, which initializes the native iOS Attentive SDK.
+ * - **Android:** this call is a no-op. The Android SDK must be initialized in native code from
+ *   your `Application.onCreate()` via `AttentiveSdk.initialize(AttentiveConfig...)`, so that
+ *   lifecycle observers register on the main thread before the React Native bridge is ready.
+ *   See the README "Android — Initialize from Native Code" section.
+ *
+ * Calling this unconditionally is safe; it is harmless on Android.
  *
  * @param configuration - Configuration object for the Attentive SDK
  */


### PR DESCRIPTION
## Ticket
[MSDK-401](https://attentivemobile.atlassian.net/browse/MSDK-401) — RN counterpart to MSDK-349 (Android) / MSDK-390 (iOS).

## Summary
Adds an agent-facing integration guide (`AGENTS.md`) for the React Native SDK so clients integrating via an AI coding agent get a fast, correctly-scoped base integration, plus a repo-internal `CLAUDE.md` and small fixes surfaced by dog-fooding the guide.

- **AGENTS.md** — base-integration guide for AI agents: npm install → iOS `pod install` + TS `initialize()` → **Android native `MainApplication.onCreate()` init** (the key RN divergence: JS `initialize()` is a no-op on Android) → build verification → README hand-off. Scoped to base integration; defers identify/events/creatives/marketing/push to the README.
- **CLAUDE.md** — repo-internal contributor guide, including a local-checkout (`file:`) + `metro.config.js` section for testing the SDK linked from a local checkout.
- **README.md** — adds a "Setup with an AI coding agent" section; repoints the stale `/example` link to `Bonni/`.
- **src/index.tsx** — corrects the `initialize()` JSDoc (Android initializes natively in `MainApplication.onCreate()`, not from JS).
- **android/build.gradle** — removes a dead GitHub Packages repo block (`attentive-android-sdk:2.1.9` resolves from Maven Central).
- **AttentiveReactNativeSdkModule.kt** — fixes stale hardcoded `sdk_version` debug strings (2.1.1 → 2.1.9).

## Test plan
- Dog-fooded end-to-end: a fresh RN app + AI agent integrated the SDK from a local checkout following `AGENTS.md`; built clean on **iOS** and **Android**.
- Confirmed `attentive-android-sdk:2.1.9` resolves from Maven Central (`.pom`/`.aar` present; it is the current `<release>`), so removing the GitHub Packages block is safe.
- `AGENTS.md` hand-off links verified against real README anchors; `tsc --noEmit` + eslint clean on the changed TypeScript.

## Verification on an open-source app

Dog-fooded `AGENTS.md` end-to-end by integrating the **published** SDK into a real, third-party, non-trivial RN app — following the guide top-to-bottom with no manual deviations.

**Target:** [`callstack/react-native-paper`](https://github.com/callstack/react-native-paper) → `example/` app (Callstack's Material Design library, 14.4k★), pinned at `466d9c6`.
**Stack:** React Native **0.85.3**, Expo SDK **56** (Continuous Native Generation — no committed `ios/`/`android/`), React 19.2.3, New Architecture.
**SDK under test:** `@attentive-mobile/attentive-react-native-sdk@2.0.2` (current npm `latest`) → `attentive-ios-sdk 2.0.13`, `attentive-android-sdk 2.1.3`.
**Toolchain:** Xcode 26.5 / Ruby 3.3.11 + CocoaPods 1.16.2 / JDK 17 / Node 20.

### Steps followed (exactly as written in AGENTS.md)
1. `yarn add @attentive-mobile/attentive-react-native-sdk` in the `example` workspace.
2. **3a (iOS, TS):** `initialize({ attentiveDomain, mode: 'debug' })` added to the existing root `useEffect` in `example/src/index.tsx`.
3. Generated native projects (Expo path): `npx expo prebuild`.
4. **3b (Android, native):** `AttentiveSdk.initialize(...)` added to `MainApplication.onCreate()`.
5. Built both platforms.

The only two edits a client makes:

```tsx
// example/src/index.tsx — inside the existing startup useEffect
const config: AttentiveSdkConfiguration = {
  attentiveDomain: 'YOUR_ATTENTIVE_DOMAIN',
  mode: 'debug',
};
initialize(config);
```

```kotlin
// android/.../MainApplication.kt — in onCreate(), after loadReactNative(this)
val attentiveConfig = AttentiveConfig.Builder()
  .applicationContext(this)
  .domain("YOUR_ATTENTIVE_DOMAIN")
  .mode(AttentiveConfig.Mode.DEBUG)
  .build()
AttentiveSdk.initialize(attentiveConfig)
```

### Results — both platforms build clean ✅

| Platform | Command | Result |
|---|---|---|
| **iOS** | `pod install` (109 pods) → `xcodebuild -sdk iphonesimulator` | `** BUILD SUCCEEDED **` — products include `attentive-ios-sdk`, `attentive-react-native-sdk`, `ReactNativePaperExample.app` |
| **Android** | `./gradlew :app:assembleDebug` | `BUILD SUCCESSFUL in 11m 37s` — `app-debug.apk` produced; `attentive-react-native-sdk` codegen ran; `MainApplication.kt` compiled |

- iOS: `attentive-react-native-sdk (2.0.2)` and `attentive-ios-sdk (2.0.13)` autolinked into the workspace.
- Android: `com.attentive:attentive-android-sdk:2.1.3` resolved from Maven Central; no unresolved references in `MainApplication.kt`.
- Per AGENTS.md, a passing build is the verification; the app was not launched on device/sim.

### Notes surfaced by the exercise
- **Validates the build-cleanup in this PR:** published 2.0.2 still ships the GitHub Packages `maven {}` block and pins `attentive-android-sdk:2.1.3`, yet Android resolves the dependency from Maven Central (listed first) — confirming this PR's removal of the GH Packages block is safe.
- **Follow-up — Expo CNG:** the guide's Expo path (`prebuild` → native dirs → bare steps) builds fine, but for Continuous-Native-Generation apps (the modern default — Bluesky, Mattermost, Rocket.Chat are all Expo too) the manual `MainApplication.onCreate()` edit lives in a **generated** directory that the next `expo prebuild`/`expo run` regenerates. Durable Android init on Expo wants a config plugin (or committing the prebuilt native dirs); Step 4's `npx react-native run-*` should also branch to `npx expo run-*` when Expo is detected. Tracked separately.
- iOS surfaces a deprecation notice: `attentive-ios-sdk has been deprecated in favor of ATTNSDKFramework` (from the 2.0.2 podspec dependency; not a build blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MSDK-401]: https://attentivemobile.atlassian.net/browse/MSDK-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
