### PR TITLE
build(ios): migrate dependency to ATTNSDKFramework (MSDK-362)

### DIFF
--- a/Bonni/ios/Podfile.lock
+++ b/Bonni/ios/Podfile.lock
@@ -1,7 +1,6 @@
 PODS:
-  - attentive-ios-sdk (2.0.13)
   - attentive-react-native-sdk (2.0.2):
-    - attentive-ios-sdk (= 2.0.13)
+    - ATTNSDKFramework (= 2.0.15)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -22,6 +21,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - ATTNSDKFramework (2.0.15)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
@@ -1802,7 +1802,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - attentive-ios-sdk
+    - ATTNSDKFramework
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -1955,8 +1955,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  attentive-ios-sdk: 087b97afeefcf0a3a3763bd003f0bb0a166b3ed4
-  attentive-react-native-sdk: 87a2ebc3763f5ba2e6c1e1a98ef4e8a60fa130f1
+  attentive-react-native-sdk: c3899d5acc2288f64df3a10e224ffbd3de0f00b9
+  ATTNSDKFramework: f80910eec46aff99b0a4381a7a5a605fa5d727b4
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6

--- a/attentive-react-native-sdk.podspec
+++ b/attentive-react-native-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
   s.public_header_files = "ios/AttentiveReactNativeSdk.h"
 
-  s.dependency 'attentive-ios-sdk', '2.0.13'
+  s.dependency 'ATTNSDKFramework', '2.0.15'
   s.swift_versions = ['5']
 
   install_modules_dependencies(s)

--- a/docs/PUSH_NOTIFICATIONS_INTEGRATION.md
+++ b/docs/PUSH_NOTIFICATIONS_INTEGRATION.md
@@ -248,7 +248,7 @@ if let sdk = AttentiveSDKManager.shared.sdk as? ATTNNativeSDK {
 If you prefer to avoid the React Native bridge entirely, you can use the Attentive iOS SDK directly. Note that this requires a separate initialization call in native code and may duplicate configuration.
 
 ```swift
-import attentive_ios_sdk
+import ATTNSDKFramework
 
 ATTNSDK.shared.registerDeviceToken(
     deviceToken,

--- a/ios/Bridging/ATTNNativeSDK.swift
+++ b/ios/Bridging/ATTNNativeSDK.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import attentive_ios_sdk
+import ATTNSDKFramework
 import UIKit
 import UserNotifications
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -20,7 +20,7 @@ target 'AttentiveReactNativeSdk' do
   flags = get_default_flags()
 
   # Ensure Swift support
-  pod 'attentive-ios-sdk', '2.0.13'
+  pod 'ATTNSDKFramework', '2.0.15'
 
   use_react_native!(
     :path => config[:reactNativePath],


### PR DESCRIPTION
## What & why

The RN SDK's iOS podspec depended on **`attentive-ios-sdk`** (`2.0.13`), which the native iOS team **deprecated in favor of `ATTNSDKFramework`** — CocoaPods printed `[!] attentive-ios-sdk has been deprecated in favor of ATTNSDKFramework` on every `pod install`, and the old pod may stop receiving updates.

This swaps the dependency to `ATTNSDKFramework` and bumps to the latest stable **`2.0.15`**. Resolves [MSDK-362](https://attentivemobile.atlassian.net/browse/MSDK-362).

## Changes

- **`attentive-react-native-sdk.podspec`** — `attentive-ios-sdk 2.0.13` → `ATTNSDKFramework 2.0.15`
- **`ios/Bridging/ATTNNativeSDK.swift`** — `import attentive_ios_sdk` → `import ATTNSDKFramework`
- **`Bonni/ios/Podfile.lock`** — regenerated via `pod install`

`ATTNSDKFramework` is the same SDK, renamed: it's still a **source pod** (`Sources/**/*.swift`, no XCFramework), and all public types/method signatures (`ATTNSDK`, `ATTNEventTracker`, `ATTNItem`, `ATTN*Event`, …) are byte-for-byte identical. The only code change is the module name on the `import` line — **no public RN API change**.

The `2.0.15` bump also makes **`clearUser()` detach the push token server-side** (added in native `2.0.14`), which closes the iOS half of the push-token gap discussed with Shields — no RN code change needed since our wrapper already calls `sdk.clearUser()`.

## Verification

- `pod install --repo-update`: **no deprecation warning**; `ATTNSDKFramework (2.0.15)` resolves; lockfile shows `attentive-react-native-sdk → ATTNSDKFramework (= 2.0.15)`, zero leftover `attentive-ios-sdk` refs.
- **Bonni iOS Debug build on the new architecture: BUILD SUCCEEDED** — `ATTNNativeSDK.swift` compiles against the new module, `Bonni.app` produced.
- `npm run typecheck` ✓, `npm test` ✓ (37 tests).
- **Expo SDK 54:** non-regression by construction — the pod is still source-compiled (no XCFramework switch), so nothing in the distribution format changed.

## Note for reviewers

CI **lint** will be red here, but **not because of this PR** — `src/eventTypes.tsx` (unchanged on this branch) has 2 pre-existing Prettier errors introduced by the merged updateUser PR (#78). A separate small PR fixes that; this branch can rebase once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-362]: https://attentivemobile.atlassian.net/browse/MSDK-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ