### PR TITLE
style: fix Prettier semicolon errors in eventTypes.tsx

### DIFF
--- a/src/eventTypes.tsx
+++ b/src/eventTypes.tsx
@@ -99,7 +99,7 @@ export interface MarketingSubscriptionParams {
  */
 export interface UpdateUserParams {
   /** Email address to set for the user */
-  email?: string;
+  email?: string
   /** E.164 phone number to set for the user */
-  phone?: string;
+  phone?: string
 }


### PR DESCRIPTION
## What & why

`npm run lint` currently **fails on `main`**: `src/eventTypes.tsx` has two Prettier errors (trailing semicolons) in the `UpdateUserParams` interface added by the merged updateUser PR (#78). The repo's ESLint/Prettier config enforces **no semicolons**.

```
src/eventTypes.tsx
  102:17  error  Delete `;`  prettier/prettier
  104:17  error  Delete `;`  prettier/prettier
```

This removes the two semicolons so the lint gate goes green again.

## Verification

- `npm run lint` ✓ (clean)
- `npm run typecheck` ✓ — no type impact (whitespace-only)

Surfaced while working on MSDK-362 (#83); split out as its own PR to keep that one scoped to the iOS dependency migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)