### PR TITLE
fix(android): route clearUser through AttentiveSdk so the push token detaches (MSDK-385)

### DIFF
--- a/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
+++ b/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
@@ -137,8 +137,41 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
         attentiveConfig?.changeDomain(domain)
     }
 
+    /**
+     * Clears the current user on logout. Routes to [AttentiveSdk.clearUser] (not the deprecated
+     * [AttentiveConfig.clearUser], which only clears local state) so the backend also detaches the
+     * push token from the prior user. On failure (e.g. the SDK was not initialized via
+     * [AttentiveSdk.initialize] in Application.onCreate()) it logs and surfaces a "Clear User Error"
+     * debug overlay rather than crashing.
+     */
     override fun clearUser() {
-        attentiveConfig?.clearUser()
+        try {
+            AttentiveSdk.clearUser()
+        } catch (e: Exception) {
+            // Include the exception class so an uninitialized SDK (IllegalStateException /
+            // UninitializedPropertyAccessException) is distinguishable from other failures.
+            Log.e(
+                TAG,
+                "clearUser failed — is AttentiveSdk.initialize() called in Application.onCreate()? " +
+                    "${e.javaClass.simpleName}: ${e.message}",
+                e
+            )
+            if (debugHelper.isDebuggingEnabled()) {
+                UiThreadUtil.runOnUiThread {
+                    debugHelper.showDebugInfo(
+                        "Clear User Error",
+                        mapOf("action" to "clearUser", "error" to (e.message ?: e.javaClass.simpleName))
+                    )
+                }
+            }
+            return
+        }
+
+        if (debugHelper.isDebuggingEnabled()) {
+            UiThreadUtil.runOnUiThread {
+                debugHelper.showDebugInfo("User Cleared", mapOf("action" to "clearUser"))
+            }
+        }
     }
 
     override fun identify(


### PR DESCRIPTION
## What & why

On Android, `clearUser` called the **deprecated** `AttentiveConfig.clearUser()` through the module's `attentiveConfig` field. That field has been **null since the native-init refactor**, so `clearUser` was a **silent no-op** — on logout the push token stayed attached to the prior user on the backend, and they could keep receiving targeted marketing on the device. Resolves [MSDK-385](https://attentivemobile.atlassian.net/browse/MSDK-385).

## Change

`AttentiveReactNativeSdkModule.clearUser()` now calls **`AttentiveSdk.clearUser()`** (native 2.1.9), which resets local identity **and** `POST`s `/user-update` to detach the push token. Per the approach agreed:
- **Switch** to the singleton (`AttentiveSdk.clearUser()`) instead of the null `attentiveConfig` field.
- **Guard** with try/catch — logs an actionable error (incl. exception class) instead of crashing if the SDK wasn't initialized in `Application.onCreate()`, matching the module's `recordEventSafely` philosophy.
- **Debug parity** — adds the `"User Cleared"` debug-overlay hook iOS already has and the other Android actions show.

One file: `android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt`.

## Verification (live, Bonni Android emulator)

Tapping **Clear User** now fires the real backend call (previously: no network at all):

```
Attentive: Resetting user identifiers with new visitor ID
AttentiveDebugHelper: showDebugInfo ... event: User Cleared, data: {action=clearUser}
OkHttp: --> POST https://mobile.attentivemobile.com/user-update   (UA: attentive-android-sdk/2.1.9)
OkHttp: <-- 200 .../user-update (185ms)
Attentive: Successfully sent clear user
```

Debug overlay shows the `User Cleared` event; no crash, no `clearUser failed`. SDK JS gates: `typecheck` ✓, `test` ✓ (37).

## Scope / notes

- **clearUser only.** `identify` / `changeDomain` / `triggerCreative` read the same null field and remain broken (the latter **crashes**) — root-caused and tracked in **[MSDK-402](https://attentivemobile.atlassian.net/browse/MSDK-402)**; fix coming on a separate branch via `AttentiveEventTracker.getInstance().config`.
- **CI lint will be red — pre-existing, not from this PR.** `src/eventTypes.tsx` has 2 Prettier errors from the merged updateUser PR (#78); fixed by open PR #84. This branch (and any off current `main`) inherits it until #84 lands. This change is Kotlin-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-385]: https://attentivemobile.atlassian.net/browse/MSDK-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MSDK-402]: https://attentivemobile.atlassian.net/browse/MSDK-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ