### PR TITLE
fix(android): repoint identify/changeDomain/triggerCreative to the initialized config (MSDK-402)

### DIFF
--- a/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
+++ b/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
@@ -100,10 +100,19 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
 
     /**
      * Returns the SDK's active [AttentiveConfig] — the one the host app installed via
-     * [AttentiveSdk.initialize] in Application.onCreate() — reached through the public
+     * [AttentiveSdk.initialize] in `Application.onCreate()` — reached through the public
      * [AttentiveEventTracker] handle so we operate on the *same* config the SDK uses (events, push,
-     * lifecycle), never a second divergent one. Returns null (logging, and surfacing [errorEvent] in
-     * the debugger) if the SDK has not been initialized yet, so callers no-op instead of crashing.
+     * lifecycle), never a second divergent one.
+     *
+     * Contract: the SDK must be initialized in `Application.onCreate()` (see [initialize]) before any
+     * bridge call. That happens-before the React Native bridge thread starts, so the config write is
+     * visible here. A host that instead initializes lazily / off the main thread (e.g. behind a
+     * consent gate) can race this read and briefly observe an uninitialized config — handled
+     * gracefully (returns null, logs, and surfaces [errorEvent] in the debugger), never a crash.
+     *
+     * Detection uses try/catch rather than `lateinit`'s `isInitialized`: that intrinsic needs the
+     * property's backing field, which Kotlin exposes only inside the declaring class, so it cannot be
+     * used on [AttentiveEventTracker]'s `config` from this module (public read access is not enough).
      *
      * @param errorEvent Debug-overlay label shown if the SDK is not initialized (e.g. "Identify Error").
      */

--- a/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
+++ b/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
@@ -45,7 +45,6 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
         private const val PUSH_PERMISSION_REQUEST_CODE = 3901
     }
 
-    private var attentiveConfig: AttentiveConfig? = null
     private var creative: Creative? = null
     private val debugHelper: AttentiveDebugHelper
 

--- a/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
+++ b/android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.annotation.NonNull
 import androidx.annotation.Nullable
 import com.attentive.androidsdk.AttentiveConfig
+import com.attentive.androidsdk.AttentiveEventTracker
 import com.attentive.androidsdk.AttentiveSdk
 import com.attentive.androidsdk.UserIdentifiers
 import com.attentive.androidsdk.creatives.Creative
@@ -97,6 +98,38 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
         )
     }
 
+    /**
+     * Returns the SDK's active [AttentiveConfig] — the one the host app installed via
+     * [AttentiveSdk.initialize] in Application.onCreate() — reached through the public
+     * [AttentiveEventTracker] handle so we operate on the *same* config the SDK uses (events, push,
+     * lifecycle), never a second divergent one. Returns null (logging, and surfacing [errorEvent] in
+     * the debugger) if the SDK has not been initialized yet, so callers no-op instead of crashing.
+     *
+     * @param errorEvent Debug-overlay label shown if the SDK is not initialized (e.g. "Identify Error").
+     */
+    private fun currentConfig(errorEvent: String): AttentiveConfig? {
+        return try {
+            AttentiveEventTracker.instance.config
+        } catch (e: Exception) {
+            // lateinit `config` throws UninitializedPropertyAccessException until the host app calls
+            // AttentiveSdk.initialize(); log the class so init issues are distinguishable.
+            Log.e(
+                TAG,
+                "$errorEvent — AttentiveSdk not initialized; call AttentiveSdk.initialize(config) in " +
+                    "Application.onCreate(). ${e.javaClass.simpleName}: ${e.message}"
+            )
+            if (debugHelper.isDebuggingEnabled()) {
+                UiThreadUtil.runOnUiThread {
+                    debugHelper.showDebugInfo(
+                        errorEvent,
+                        mapOf("error" to "AttentiveSdk not initialized in Application.onCreate()")
+                    )
+                }
+            }
+            null
+        }
+    }
+
     override fun triggerCreative(creativeId: String?) {
         Log.i(TAG, "Native Attentive module was called to trigger the creative.")
         try {
@@ -106,7 +139,8 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
                     currentActivity.window.decorView.rootView as ViewGroup
                 // The following calls edit the view hierarchy so they must run on the UI thread
                 UiThreadUtil.runOnUiThread {
-                    creative = Creative(attentiveConfig!!, rootView, currentActivity)
+                    val config = currentConfig("Creative Error") ?: return@runOnUiThread
+                    creative = Creative(config, rootView, currentActivity)
                     creative?.trigger(null, creativeId)
                     if (debugHelper.isDebuggingEnabled()) {
                         val debugData = mutableMapOf<String, Any>()
@@ -134,7 +168,13 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
     }
 
     override fun updateDomain(domain: String) {
-        attentiveConfig?.changeDomain(domain)
+        val config = currentConfig("Update Domain Error") ?: return
+        config.changeDomain(domain)
+        if (debugHelper.isDebuggingEnabled()) {
+            UiThreadUtil.runOnUiThread {
+                debugHelper.showDebugInfo("Domain Updated", mapOf("domain" to domain))
+            }
+        }
     }
 
     override fun clearUser() {
@@ -176,7 +216,20 @@ class AttentiveReactNativeSdkModule(reactContext: ReactApplicationContext) :
             idsBuilder.withCustomIdentifiers(customIds)
         }
 
-        attentiveConfig?.identify(idsBuilder.build())
+        val config = currentConfig("Identify Error") ?: return
+        config.identify(idsBuilder.build())
+
+        if (debugHelper.isDebuggingEnabled()) {
+            val debugData = mutableMapOf<String, Any>()
+            if (!phone.isNullOrEmpty()) debugData["phone"] = phone
+            if (!email.isNullOrEmpty()) debugData["email"] = email
+            if (!klaviyoId.isNullOrEmpty()) debugData["klaviyoId"] = klaviyoId
+            if (!shopifyId.isNullOrEmpty()) debugData["shopifyId"] = shopifyId
+            if (!clientUserId.isNullOrEmpty()) debugData["clientUserId"] = clientUserId
+            UiThreadUtil.runOnUiThread {
+                debugHelper.showDebugInfo("User Identified", debugData)
+            }
+        }
     }
 
     override fun recordProductViewEvent(items: ReadableArray, deeplink: String?) {


### PR DESCRIPTION
## What & why

On Android these three bridge methods read the module's `attentiveConfig` field, which has been **null since init moved to the host app's `Application.onCreate()`** (`b862c53`). So:
- **`triggerCreative` crashed** — `Creative(attentiveConfig!!, …)` → uncaught `NullPointerException` (the `!!` came in `5d0d509`).
- **`identify` / `updateDomain` silently no-op'd.**

Shipped since 2.0.1. Part of **[MSDK-402](https://attentivemobile.atlassian.net/browse/MSDK-402)**.

## Change

Repoint all three to the SDK's **actual initialized config** via the public, `@JvmStatic` **`AttentiveEventTracker.instance.config`** — the *same* `AttentiveConfig` the host app passed to `AttentiveSdk.initialize()` (verified: `AttentiveSdk.initialize()` calls `AttentiveEventTracker.instance.initializeInternal(config)`). A guarded helper returns null — logging + a debug overlay — instead of crashing if the SDK isn't initialized:

```kotlin
private fun currentConfig(errorEvent: String): AttentiveConfig? =
    try { AttentiveEventTracker.instance.config }
    catch (e: Exception) { Log.e(TAG, "$errorEvent — AttentiveSdk not initialized…"); /* + overlay */ null }
```

- `triggerCreative` → `currentConfig("Creative Error")?.let { Creative(it, …) }` — **drops the crashing `!!`**.
- `identify` → `currentConfig("Identify Error")?.identify(ids)`
- `updateDomain` → `currentConfig("Update Domain Error")?.changeDomain(domain)`
- Adds success/error debug-overlay parity for all three (consistent with the other Android methods + iOS).

One file: `android/src/main/kotlin/com/attentivereactnativesdk/AttentiveReactNativeSdkModule.kt`.

### Deliberately NOT done
- **No module-side `AttentiveConfig`** — building one here would reintroduce the dual-init / split-brain that `b862c53` removed (the module's TS args even carry a different domain than the host app's config).

## Verification (live, Bonni Android emulator)

Tapping **Show Creative** — previously a `FATAL EXCEPTION: main` NPE at `…Module.kt:109` — now constructs `Creative` with a real config and **renders the WebView creative** ("Unlock 10% off your order / GET 10% OFF NOW"). App stays alive; `"Creative Triggered"` debug event logged. `identify`/`changeDomain` go through the identical `currentConfig()` helper and the same (proven-valid) config object. `typecheck` ✓, `test` ✓ (37).

## Scope / merge notes

- **`clearUser` is separate** — PR #85 (MSDK-385) routes it to `AttentiveSdk.clearUser()`.
- This branch is off current `main`, where `clearUser` still reads `attentiveConfig`, so **the `attentiveConfig` field stays** here. Once #85 merges and this rebases, all four readers are gone and the dead field can be deleted (follow-up in this PR or a cleanup).
- **Instrumented smoke test** (MSDK-402 AC) suggested as a separate follow-up rather than bloating this PR.
- **CI lint red is pre-existing** (`src/eventTypes.tsx`, PR #78; fixed by open PR #84) — not from this Kotlin change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-402]: https://attentivemobile.atlassian.net/browse/MSDK-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ