### PR TITLE
chore: release 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@attentive-mobile/attentive-react-native-sdk",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@attentive-mobile/attentive-react-native-sdk",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attentive-mobile/attentive-react-native-sdk",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "React Native Module for the Attentive SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Version bump for the **2.1.0** release, which is **already published** (npm + tag `2.1.0` + GitHub release). This PR just brings `main`'s `package.json`/lockfile to 2.1.0 — the release is live, so merging is a non-blocking formality.

⚠️ **Merge with a merge commit — NOT squash/rebase.** The `2.1.0` tag points to this branch's release commit; squashing would orphan the tag (the exact issue we just had to fix on `2.0.2`). If it must be squashed, re-point the `2.1.0` tag to the squashed commit afterward.

- npm: https://www.npmjs.com/package/@attentive-mobile/attentive-react-native-sdk/v/2.1.0
- release: https://github.com/attentive-mobile/attentive-react-native-sdk/releases/tag/2.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)