### PR TITLE
ci: Bonni tester distribution (Phase B — iOS TestFlight + Android Firebase)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,12 @@ executors:
       FASTLANE_SKIP_UPDATE_CHECK: "YES"
       LC_ALL: "en_US.UTF-8"
       LANG: "en_US.UTF-8"
+  # Android runner for building the signed Bonni APK + Firebase App Distribution upload.
+  # The "-node" cimg/android variant bundles Node.js (needed for the RN JS bundle step).
+  android-executor:
+    docker:
+      - image: cimg/android:2026.02.1-node
+    resource_class: large
 
 # ========================
 # Commands (Reusable)
@@ -438,6 +444,60 @@ jobs:
             - notify-slack-on-testflight-success
             - notify-slack-on-failure
 
+  # -----------------------
+  # Distribute Bonni to Firebase App Distribution (Android)
+  # -----------------------
+  # Builds the signed Bonni APK and uploads it to Firebase App Distribution, mirroring the
+  # native Android SDK's distribute-bonni job. Reuses the workspace from setup-bonni (SDK lib/
+  # + Bonni node_modules + git history), then self-halts unless the Bonni versionCode changed
+  # — so a build ships to testers only on an explicit bump.
+  distribute-bonni-android:
+    executor: android-executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Skip unless Bonni versionCode changed
+          command: |
+            CURRENT=$(grep -E "versionCode\s+[0-9]+" Bonni/android/app/build.gradle | grep -oE "[0-9]+" | head -1)
+            git fetch origin "$CIRCLE_BRANCH" >/dev/null 2>&1 || true
+            PREVIOUS=$(git show "origin/${CIRCLE_BRANCH}^:Bonni/android/app/build.gradle" 2>/dev/null | grep -E "versionCode\s+[0-9]+" | grep -oE "[0-9]+" | head -1 || echo "")
+            echo "Bonni versionCode: previous='${PREVIOUS}' current='${CURRENT}'"
+            if [ "$CURRENT" = "$PREVIOUS" ]; then
+              echo "versionCode unchanged -- skipping Bonni distribution."
+              circleci-agent step halt
+            fi
+      - run:
+          name: Decode release keystore
+          command: echo "$BONNI_KEYSTORE_BASE64" | base64 -d > Bonni/android/app/bonni-release.keystore
+      - run:
+          name: Build Bonni release APK
+          command: |
+            cd Bonni/android
+            ./gradlew :app:assembleRelease
+      - run:
+          name: Install Firebase CLI
+          command: |
+            if ! command -v firebase >/dev/null 2>&1; then
+              npm install -g firebase-tools
+            fi
+      - run:
+          name: Upload to Firebase App Distribution
+          command: |
+            firebase appdistribution:distribute \
+              Bonni/android/app/build/outputs/apk/release/app-release.apk \
+              --app "$FIREBASE_APP_ID" \
+              --token "$FIREBASE_TOKEN" \
+              --groups "dev, product-+-eng"
+      - run:
+          name: Cleanup keystore
+          when: always
+          command: rm -f Bonni/android/app/bonni-release.keystore
+      - store_artifacts:
+          path: Bonni/android/app/build/outputs/apk/release
+          destination: bonni-android-apk
+      - notify-slack-on-failure
+
 # ========================
 # Workflows
 # ========================
@@ -479,6 +539,15 @@ workflows:
           context: *default_context
           requires:
             - setup-bonni
+      # On main only, ship a new Bonni build to testers (Firebase App Distribution)
+      # when its versionCode was bumped. The job itself self-halts if it wasn't.
+      - distribute-bonni-android:
+          context: *default_context
+          requires:
+            - setup-bonni
+          filters:
+            branches:
+              only: main
 
   # Release: triggered via the CircleCI API from the GitHub Actions "Release"
   # workflow (run_release=true). Runs the full validation suite as gates, then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,8 +456,12 @@ jobs:
           name: Skip unless Bonni versionCode changed
           command: |
             CURRENT=$(grep -E "versionCode\s+[0-9]+" Bonni/android/app/build.gradle | grep -oE "[0-9]+" | head -1)
-            git fetch origin "$CIRCLE_BRANCH" >/dev/null 2>&1 || true
-            PREVIOUS=$(git show "origin/${CIRCLE_BRANCH}^:Bonni/android/app/build.gradle" 2>/dev/null | grep -E "versionCode\s+[0-9]+" | grep -oE "[0-9]+" | head -1 || echo "")
+            # Compare against the parent of THIS pipeline's commit ($CIRCLE_SHA1~1), which is
+            # immutable, rather than the live-moving origin/$CIRCLE_BRANCH^: a concurrent push to
+            # main between trigger and this step could advance the branch ref onto our own commit,
+            # making a real versionCode bump read as "unchanged" and silently halting the upload.
+            # The full git history is present here (checkout-and-setup persists .git), so no fetch.
+            PREVIOUS=$(git show "${CIRCLE_SHA1}~1:Bonni/android/app/build.gradle" 2>/dev/null | grep -E "versionCode\s+[0-9]+" | grep -oE "[0-9]+" | head -1 || echo "")
             echo "Bonni versionCode: previous='${PREVIOUS}' current='${CURRENT}'"
             if [ "$CURRENT" = "$PREVIOUS" ]; then
               echo "versionCode unchanged -- skipping Bonni distribution."
@@ -539,8 +543,15 @@ workflows:
       # when its versionCode was bumped. The job itself self-halts if it wasn't.
       - distribute-bonni-android:
           context: *default_context
+          # Gate on the full validation suite (same as release / deploy-bonni-testflight) so a
+          # Bonni build that fails CI can't ship to Firebase testers on a versionCode bump.
           requires:
-            - setup-bonni
+            - lint
+            - typecheck
+            - unit-test
+            - lint-bonni
+            - typecheck-bonni
+            - test-bonni
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,11 +484,14 @@ jobs:
       - run:
           name: Upload to Firebase App Distribution
           command: |
+            # Group aliases: comma-separated with NO spaces. "product-+-eng" is a real alias
+            # (verified via appdistribution:group:list); some firebase-tools versions don't trim,
+            # so a stray space could look up " product-+-eng" and silently miss that group.
             firebase appdistribution:distribute \
               Bonni/android/app/build/outputs/apk/release/app-release.apk \
               --app "$FIREBASE_APP_ID" \
               --token "$FIREBASE_TOKEN" \
-              --groups "dev, product-+-eng"
+              --groups "dev,product-+-eng"
       - run:
           name: Cleanup keystore
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,23 @@ jobs:
               circleci-agent step halt
             fi
       - run:
+          name: Verify required signing + Firebase env vars are present
+          command: |
+            # Hard-fail if any required var is missing. Without this, a release build
+            # with BONNI_STORE_PASSWORD unset silently falls back to the DEBUG keystore
+            # (build.gradle) and we'd upload a debug-signed "release" APK to testers.
+            missing=""
+            for var in BONNI_KEYSTORE_BASE64 BONNI_STORE_PASSWORD BONNI_KEY_ALIAS BONNI_KEY_PASSWORD FIREBASE_APP_ID FIREBASE_TOKEN; do
+              if [ -z "$(printenv "$var" || true)" ]; then
+                missing="$missing $var"
+              fi
+            done
+            if [ -n "$missing" ]; then
+              echo "Missing required env var(s):$missing" >&2
+              echo "Refusing to build/upload: a release build without the signing vars would be debug-signed." >&2
+              exit 1
+            fi
+      - run:
           name: Decode release keystore
           command: echo "$BONNI_KEYSTORE_BASE64" | base64 -d > Bonni/android/app/bonni-release.keystore
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,7 +387,7 @@ jobs:
             git checkout "${CIRCLE_SHA1}"
       # Temporary AWS creds (OIDC) so fastlane match can read certs/profiles from S3.
       - aws-cli/setup:
-          region: $AWS_REGION
+          region: AWS_REGION
           role_arn: $AWS_ROLE_ARN
           role_session_name: $CIRCLE_JOB-<< pipeline.number >>
       - macos/switch-ruby:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ orbs:
   slack: circleci/slack@6.1.3
   github-cli: circleci/github-cli@2.7.2
   attentive: attentive-mobile/circleci-orb@0.0.11
+  macos: circleci/macos@2
+  aws-cli: circleci/aws-cli@4.0.0
 
 # ========================
 # Pipeline parameters
@@ -27,6 +29,11 @@ parameters:
   release_notes:
     type: string
     default: ""
+  # Set true by the GitHub Actions "Deploy TestFlight" workflow to build + upload the
+  # Bonni app to TestFlight without cutting an SDK release. Mirrors the iOS SDK pipeline.
+  run_testflight_deploy:
+    type: boolean
+    default: false
 
 # ========================
 # Constants
@@ -49,6 +56,18 @@ executors:
     docker:
       - image: cimg/node:22.14.0
     resource_class: medium
+  # macOS runner for building/signing/uploading the Bonni iOS app to TestFlight.
+  # Xcode 26.1.1 + m4pro.medium match the native iOS SDK pipeline (and the Bonni
+  # Podfile's fmt C++17 / Xcode 26 workaround).
+  macos-xcode:
+    macos:
+      xcode: "26.1.1"
+    resource_class: m4pro.medium
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      FASTLANE_SKIP_UPDATE_CHECK: "YES"
+      LC_ALL: "en_US.UTF-8"
+      LANG: "en_US.UTF-8"
 
 # ========================
 # Commands (Reusable)
@@ -81,6 +100,23 @@ commands:
           event: pass
           custom: |
             ${SLACK_RELEASE_PAYLOAD}
+
+  notify-slack-on-testflight-success:
+    description: "Announce a successful Bonni TestFlight upload to #eng-mobile-sdk-releases"
+    steps:
+      - slack/notify:
+          channel: *slack_channel_releases
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                { "type": "header", "text": { "type": "plain_text", "text": "✅ Bonni TestFlight Build Deployed", "emoji": true } },
+                { "type": "section", "fields": [
+                  { "type": "mrkdwn", "text": "*Build:*\n${TESTFLIGHT_BUILD_NUMBER}" },
+                  { "type": "mrkdwn", "text": "*Branch:*\n${CIRCLE_BRANCH}" }
+                ] }
+              ]
+            }
 
 # ========================
 # Jobs
@@ -316,14 +352,102 @@ jobs:
       - notify-slack-on-release-success
       - notify-slack-on-failure
 
+  # -----------------------
+  # Deploy Bonni to TestFlight (iOS)
+  # -----------------------
+  # macOS job: builds + signs the Bonni RN app and uploads it to TestFlight via fastlane.
+  # Runs only in the deploy-testflight workflow (run_testflight_deploy=true); skipped for
+  # prereleases. Self-contained (build + upload in one job) to avoid passing the IPA + gems
+  # + repo across macOS jobs. Mirrors the iOS SDK's build_bonni_release + deploy_testflight.
+  deploy-bonni-testflight:
+    executor: macos-xcode
+    steps:
+      - run:
+          name: Check prerelease
+          command: echo "is_prerelease=<< pipeline.parameters.is_prerelease >>"
+      - unless:
+          condition:
+            equal: ["true", << pipeline.parameters.is_prerelease >>]
+          steps:
+            # API-triggered pipelines don't get a write-capable checkout by default; clone
+            # with the GitHub App token (read is enough here, but keeps parity with release).
+            - attentive/app-based-github-token:
+                github_app_client_id: ${GITHUB_APP_CLIENT_ID}
+                github_app_private_key_base64: ${GITHUB_APP_PRIVATE_KEY_BASE64}
+                github_app_installation_id: ${GITHUB_APP_INSTALLATION_ID}
+            - run:
+                name: Checkout via GitHub App token
+                command: |
+                  AUTH_HEADER="http.https://github.com/.extraheader=Authorization: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w 0)"
+                  git -c "${AUTH_HEADER}" clone --filter=blob:none \
+                    "https://github.com/attentive-mobile/attentive-react-native-sdk.git" .
+                  git -c "${AUTH_HEADER}" fetch --filter=blob:none origin "${CIRCLE_SHA1}"
+                  git checkout "${CIRCLE_SHA1}"
+            # Temporary AWS creds (OIDC) so fastlane match can read certs/profiles from S3.
+            - aws-cli/setup:
+                region: AWS_REGION
+                role_arn: $AWS_ROLE_ARN
+                role_session_name: $CIRCLE_JOB-<< pipeline.number >>
+            - macos/switch-ruby:
+                version: "3.3"
+            - run:
+                name: Select Node 20 (RN toolchain)
+                command: |
+                  export NVM_DIR="$HOME/.nvm"
+                  # shellcheck disable=SC1090
+                  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+                  nvm install 20
+                  nvm alias default 20
+                  # Persist the selected node on PATH for later steps.
+                  echo "export NVM_DIR=$NVM_DIR" >> "$BASH_ENV"
+                  echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20 >/dev/null' >> "$BASH_ENV"
+                  node -v && npm -v
+            - run:
+                name: Install SDK deps + build lib/
+                # Bonni resolves the SDK via `file:..`; its gitignored lib/ must be built first.
+                command: |
+                  npm ci
+                  npm run build
+            - run:
+                name: Install Bonni JS deps
+                command: npm --prefix Bonni ci
+            - run:
+                name: Install Ruby gems (fastlane + cocoapods)
+                command: |
+                  cd Bonni
+                  bundle config set --local path 'vendor/bundle'
+                  bundle install
+            - run:
+                name: Install Pods
+                command: |
+                  cd Bonni/ios
+                  bundle exec pod install
+            - run:
+                name: Build Bonni release IPA (fastlane match + gym)
+                command: |
+                  cd Bonni/ios
+                  bundle exec fastlane build_bonni_release
+            - run:
+                name: Upload to TestFlight (fastlane pilot)
+                command: |
+                  cd Bonni/ios
+                  bundle exec fastlane deploy_testflight
+            - store_artifacts:
+                path: Bonni/ios/build
+                destination: bonni-ios
+            - notify-slack-on-testflight-success
+            - notify-slack-on-failure
+
 # ========================
 # Workflows
 # ========================
 workflows:
-  # Normal CI: runs on every push/PR. Disabled during a release pipeline.
+  # Normal CI: runs on every push/PR. Disabled during a release or TestFlight pipeline.
   lint-typecheck-test:
     when:
-      not: << pipeline.parameters.run_release >>
+      and:
+        - not: << pipeline.parameters.run_release >>
+        - not: << pipeline.parameters.run_testflight_deploy >>
     jobs:
       - checkout-and-setup:
           context: *default_context
@@ -401,3 +525,12 @@ workflows:
             - lint-bonni
             - typecheck-bonni
             - test-bonni
+
+  # Deploy Bonni to TestFlight: triggered via the CircleCI API from the GitHub Actions
+  # "Deploy TestFlight" workflow (run_testflight_deploy=true). Builds + uploads the Bonni
+  # app; does not cut an SDK release.
+  deploy-testflight:
+    when: << pipeline.parameters.run_testflight_deploy >>
+    jobs:
+      - deploy-bonni-testflight:
+          context: *default_context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,87 +362,83 @@ jobs:
   # Deploy Bonni to TestFlight (iOS)
   # -----------------------
   # macOS job: builds + signs the Bonni RN app and uploads it to TestFlight via fastlane.
-  # Runs only in the deploy-testflight workflow (run_testflight_deploy=true); skipped for
-  # prereleases. Self-contained (build + upload in one job) to avoid passing the IPA + gems
-  # + repo across macOS jobs. Mirrors the iOS SDK's build_bonni_release + deploy_testflight.
+  # Runs only in the deploy-testflight workflow (run_testflight_deploy=true), after the
+  # validation jobs pass. Self-contained (build + upload in one job) to avoid passing the
+  # IPA + gems + repo across macOS jobs. Mirrors the iOS SDK's build_bonni_release +
+  # deploy_testflight lanes. (No is_prerelease guard: this workflow is only ever triggered
+  # by the Deploy TestFlight GitHub Action, which never sets is_prerelease -- a guard here
+  # would be dead code that could silently no-op the whole job while reporting success.)
   deploy-bonni-testflight:
     executor: macos-xcode
     steps:
+      # API-triggered pipelines don't get a write-capable checkout by default; clone
+      # with the GitHub App token (read is enough here, but keeps parity with release).
+      - attentive/app-based-github-token:
+          github_app_client_id: ${GITHUB_APP_CLIENT_ID}
+          github_app_private_key_base64: ${GITHUB_APP_PRIVATE_KEY_BASE64}
+          github_app_installation_id: ${GITHUB_APP_INSTALLATION_ID}
       - run:
-          name: Check prerelease
-          command: echo "is_prerelease=<< pipeline.parameters.is_prerelease >>"
-      - unless:
-          condition:
-            equal: ["true", << pipeline.parameters.is_prerelease >>]
-          steps:
-            # API-triggered pipelines don't get a write-capable checkout by default; clone
-            # with the GitHub App token (read is enough here, but keeps parity with release).
-            - attentive/app-based-github-token:
-                github_app_client_id: ${GITHUB_APP_CLIENT_ID}
-                github_app_private_key_base64: ${GITHUB_APP_PRIVATE_KEY_BASE64}
-                github_app_installation_id: ${GITHUB_APP_INSTALLATION_ID}
-            - run:
-                name: Checkout via GitHub App token
-                command: |
-                  AUTH_HEADER="http.https://github.com/.extraheader=Authorization: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w 0)"
-                  git -c "${AUTH_HEADER}" clone --filter=blob:none \
-                    "https://github.com/attentive-mobile/attentive-react-native-sdk.git" .
-                  git -c "${AUTH_HEADER}" fetch --filter=blob:none origin "${CIRCLE_SHA1}"
-                  git checkout "${CIRCLE_SHA1}"
-            # Temporary AWS creds (OIDC) so fastlane match can read certs/profiles from S3.
-            - aws-cli/setup:
-                region: AWS_REGION
-                role_arn: $AWS_ROLE_ARN
-                role_session_name: $CIRCLE_JOB-<< pipeline.number >>
-            - macos/switch-ruby:
-                version: "3.3"
-            - run:
-                name: Select Node 20 (RN toolchain)
-                command: |
-                  export NVM_DIR="$HOME/.nvm"
-                  # shellcheck disable=SC1090
-                  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-                  nvm install 20
-                  nvm alias default 20
-                  # Persist the selected node on PATH for later steps.
-                  echo "export NVM_DIR=$NVM_DIR" >> "$BASH_ENV"
-                  echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20 >/dev/null' >> "$BASH_ENV"
-                  node -v && npm -v
-            - run:
-                name: Install SDK deps + build lib/
-                # Bonni resolves the SDK via `file:..`; its gitignored lib/ must be built first.
-                command: |
-                  npm ci
-                  npm run build
-            - run:
-                name: Install Bonni JS deps
-                command: npm --prefix Bonni ci
-            - run:
-                name: Install Ruby gems (fastlane + cocoapods)
-                command: |
-                  cd Bonni
-                  bundle config set --local path 'vendor/bundle'
-                  bundle install
-            - run:
-                name: Install Pods
-                command: |
-                  cd Bonni/ios
-                  bundle exec pod install
-            - run:
-                name: Build Bonni release IPA (fastlane match + gym)
-                command: |
-                  cd Bonni/ios
-                  bundle exec fastlane build_bonni_release
-            - run:
-                name: Upload to TestFlight (fastlane pilot)
-                command: |
-                  cd Bonni/ios
-                  bundle exec fastlane deploy_testflight
-            - store_artifacts:
-                path: Bonni/ios/build
-                destination: bonni-ios
-            - notify-slack-on-testflight-success
-            - notify-slack-on-failure
+          name: Checkout via GitHub App token
+          command: |
+            AUTH_HEADER="http.https://github.com/.extraheader=Authorization: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w 0)"
+            git -c "${AUTH_HEADER}" clone --filter=blob:none \
+              "https://github.com/attentive-mobile/attentive-react-native-sdk.git" .
+            git -c "${AUTH_HEADER}" fetch --filter=blob:none origin "${CIRCLE_SHA1}"
+            git checkout "${CIRCLE_SHA1}"
+      # Temporary AWS creds (OIDC) so fastlane match can read certs/profiles from S3.
+      - aws-cli/setup:
+          region: $AWS_REGION
+          role_arn: $AWS_ROLE_ARN
+          role_session_name: $CIRCLE_JOB-<< pipeline.number >>
+      - macos/switch-ruby:
+          version: "3.3"
+      - run:
+          name: Select Node 20 (RN toolchain)
+          command: |
+            export NVM_DIR="$HOME/.nvm"
+            # shellcheck disable=SC1090
+            [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+            nvm install 20
+            nvm alias default 20
+            # Persist the selected node on PATH for later steps.
+            echo "export NVM_DIR=$NVM_DIR" >> "$BASH_ENV"
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 20 >/dev/null' >> "$BASH_ENV"
+            node -v && npm -v
+      - run:
+          name: Install SDK deps + build lib/
+          # Bonni resolves the SDK via `file:..`; its gitignored lib/ must be built first.
+          command: |
+            npm ci
+            npm run build
+      - run:
+          name: Install Bonni JS deps
+          command: npm --prefix Bonni ci
+      - run:
+          name: Install Ruby gems (fastlane + cocoapods)
+          command: |
+            cd Bonni
+            bundle config set --local path 'vendor/bundle'
+            bundle install
+      - run:
+          name: Install Pods
+          command: |
+            cd Bonni/ios
+            bundle exec pod install
+      - run:
+          name: Build Bonni release IPA (fastlane match + gym)
+          command: |
+            cd Bonni/ios
+            bundle exec fastlane build_bonni_release
+      - run:
+          name: Upload to TestFlight (fastlane pilot)
+          command: |
+            cd Bonni/ios
+            bundle exec fastlane deploy_testflight
+      - store_artifacts:
+          path: Bonni/ios/build
+          destination: bonni-ios
+      - notify-slack-on-testflight-success
+      - notify-slack-on-failure
 
   # -----------------------
   # Distribute Bonni to Firebase App Distribution (Android)
@@ -596,10 +592,51 @@ workflows:
             - test-bonni
 
   # Deploy Bonni to TestFlight: triggered via the CircleCI API from the GitHub Actions
-  # "Deploy TestFlight" workflow (run_testflight_deploy=true). Builds + uploads the Bonni
-  # app; does not cut an SDK release.
+  # "Deploy TestFlight" workflow (run_testflight_deploy=true). Validation gates run first so a
+  # broken build can't ship to testers; `not run_release` keeps it mutually exclusive with the
+  # release-sdk workflow if both params are ever set in one pipeline.
   deploy-testflight:
-    when: << pipeline.parameters.run_testflight_deploy >>
+    when:
+      and:
+        - << pipeline.parameters.run_testflight_deploy >>
+        - not: << pipeline.parameters.run_release >>
     jobs:
+      - checkout-and-setup:
+          context: *default_context
+      - lint:
+          context: *default_context
+          requires:
+            - checkout-and-setup
+      - typecheck:
+          context: *default_context
+          requires:
+            - checkout-and-setup
+      - unit-test:
+          context: *default_context
+          requires:
+            - checkout-and-setup
+      - setup-bonni:
+          context: *default_context
+          requires:
+            - checkout-and-setup
+      - lint-bonni:
+          context: *default_context
+          requires:
+            - setup-bonni
+      - typecheck-bonni:
+          context: *default_context
+          requires:
+            - setup-bonni
+      - test-bonni:
+          context: *default_context
+          requires:
+            - setup-bonni
       - deploy-bonni-testflight:
           context: *default_context
+          requires:
+            - lint
+            - typecheck
+            - unit-test
+            - lint-bonni
+            - typecheck-bonni
+            - test-bonni

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -14,15 +14,26 @@ on:
         default: "main"
         type: string
 
+# Two overlapping TestFlight dispatches would race on the App Store Connect build number
+# (the second upload gets rejected with ITMS-90062). Serialize them.
+concurrency:
+  group: bonni-testflight
+  cancel-in-progress: false
+
 jobs:
   trigger-testflight:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger CircleCI deploy-testflight pipeline
         id: trigger
+        env:
+          # Pass the input through env, not direct ${{ }} interpolation into the script:
+          # GHA substitutes ${{ }} as literal text before bash runs, so a crafted branch
+          # name would inject shell (jq --arg does NOT protect against that).
+          BRANCH: ${{ inputs.branch }}
         run: |
           payload=$(jq -n \
-            --arg branch "${{ inputs.branch }}" \
+            --arg branch "$BRANCH" \
             '{
               branch: $branch,
               parameters: {
@@ -55,14 +66,14 @@ jobs:
 
           echo "pipeline_id=$pipeline_id" >> "$GITHUB_OUTPUT"
           echo "pipeline_number=$pipeline_number" >> "$GITHUB_OUTPUT"
-          echo "CircleCI TestFlight pipeline triggered for branch ${{ inputs.branch }} (pipeline: $pipeline_number)"
+          echo "CircleCI TestFlight pipeline triggered for branch $BRANCH (pipeline: $pipeline_number)"
 
       - name: Wait for CircleCI pipeline to complete
         run: |
           pipeline_id="${{ steps.trigger.outputs.pipeline_id }}"
           pipeline_number="${{ steps.trigger.outputs.pipeline_number }}"
           poll_interval=30
-          timeout=2700  # 45 minutes
+          timeout=3600  # 60 minutes (cold-cache RN iOS builds are slow)
           elapsed=0
 
           echo "Waiting for CircleCI pipeline $pipeline_number to complete..."
@@ -104,7 +115,7 @@ jobs:
 
               case "$status" in
                 success) ;;
-                failed|error|canceled|unauthorized)
+                failed|error|canceled|unauthorized|not_run|on_hold)
                   any_failed=true
                   ;;
                 *)

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -1,0 +1,137 @@
+name: Deploy TestFlight
+
+# Manual trigger that builds the Bonni app and uploads it to TestFlight, without cutting an
+# SDK release. Dispatches the CircleCI `deploy-testflight` workflow (run_testflight_deploy=true)
+# and waits for it. Mirrors the iOS SDK's deploy-testflight workflow. Unlike the Release
+# workflow, this is not pinned to main — a `branch` input lets QA push a branch build to
+# TestFlight (internal testers only; no npm publish, reversible).
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to build and deploy to TestFlight"
+        required: true
+        default: "main"
+        type: string
+
+jobs:
+  trigger-testflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CircleCI deploy-testflight pipeline
+        id: trigger
+        run: |
+          payload=$(jq -n \
+            --arg branch "${{ inputs.branch }}" \
+            '{
+              branch: $branch,
+              parameters: {
+                run_testflight_deploy: true
+              }
+            }')
+
+          response=$(curl -s -w "\n%{http_code}" -X POST \
+            "https://circleci.com/api/v2/project/${{ vars.CIRCLECI_PROJECT_SLUG }}/pipeline" \
+            -H "Circle-Token: ${{ secrets.CIRCLECI_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+
+          http_code=$(echo "$response" | tail -1)
+          body=$(echo "$response" | sed '$d')
+
+          echo "$body" | jq . 2>/dev/null || echo "$body"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::CircleCI API returned HTTP $http_code"
+            exit 1
+          fi
+
+          pipeline_id=$(echo "$body" | jq -r '.id')
+          pipeline_number=$(echo "$body" | jq -r '.number')
+          if [ -z "$pipeline_id" ] || [ "$pipeline_id" = "null" ]; then
+            echo "::error::Could not extract pipeline ID from CircleCI response"
+            exit 1
+          fi
+
+          echo "pipeline_id=$pipeline_id" >> "$GITHUB_OUTPUT"
+          echo "pipeline_number=$pipeline_number" >> "$GITHUB_OUTPUT"
+          echo "CircleCI TestFlight pipeline triggered for branch ${{ inputs.branch }} (pipeline: $pipeline_number)"
+
+      - name: Wait for CircleCI pipeline to complete
+        run: |
+          pipeline_id="${{ steps.trigger.outputs.pipeline_id }}"
+          pipeline_number="${{ steps.trigger.outputs.pipeline_number }}"
+          poll_interval=30
+          timeout=2700  # 45 minutes
+          elapsed=0
+
+          echo "Waiting for CircleCI pipeline $pipeline_number to complete..."
+          echo "Pipeline URL: https://app.circleci.com/pipelines/${{ vars.CIRCLECI_PROJECT_SLUG }}/${pipeline_number}"
+
+          while [ "$elapsed" -lt "$timeout" ]; do
+            api_response=$(curl -s -w "\n%{http_code}" -X GET \
+              "https://circleci.com/api/v2/pipeline/${pipeline_id}/workflow" \
+              -H "Circle-Token: ${{ secrets.CIRCLECI_TOKEN }}" \
+              -H "Content-Type: application/json")
+
+            http_code=$(echo "$api_response" | tail -1)
+            response=$(echo "$api_response" | sed '$d')
+
+            if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+              echo "::error::CircleCI API returned HTTP $http_code while polling workflows"
+              echo "$response"
+              exit 1
+            fi
+
+            workflow_count=$(echo "$response" | jq '.items | length')
+
+            if [ "$workflow_count" -eq 0 ]; then
+              echo "No workflows found yet, waiting..."
+              sleep "$poll_interval"
+              elapsed=$((elapsed + poll_interval))
+              continue
+            fi
+
+            all_terminal=true
+            any_failed=false
+            summary=""
+
+            for i in $(seq 0 $((workflow_count - 1))); do
+              name=$(echo "$response" | jq -r ".items[$i].name")
+              status=$(echo "$response" | jq -r ".items[$i].status")
+              wf_id=$(echo "$response" | jq -r ".items[$i].id")
+              summary="${summary}  - ${name}: ${status} (https://app.circleci.com/pipelines/${{ vars.CIRCLECI_PROJECT_SLUG }}/${pipeline_number}/workflows/${wf_id})\n"
+
+              case "$status" in
+                success) ;;
+                failed|error|canceled|unauthorized)
+                  any_failed=true
+                  ;;
+                *)
+                  all_terminal=false
+                  ;;
+              esac
+            done
+
+            if [ "$all_terminal" = true ]; then
+              echo ""
+              echo "All workflows finished:"
+              echo -e "$summary"
+
+              if [ "$any_failed" = true ]; then
+                echo "::error::One or more CircleCI workflows did not succeed"
+                exit 1
+              else
+                echo "TestFlight deploy completed successfully!"
+                exit 0
+              fi
+            fi
+
+            echo "[$(date -u +%H:%M:%S)] Workflows still running (${elapsed}s elapsed)..."
+            echo -e "$summary"
+            sleep "$poll_interval"
+            elapsed=$((elapsed + poll_interval))
+          done
+
+          echo "::error::Timed out after ${timeout}s waiting for CircleCI pipeline to complete"
+          exit 1

--- a/Bonni/Gemfile
+++ b/Bonni/Gemfile
@@ -4,3 +4,4 @@ ruby ">= 3.3.0"
 
 gem 'cocoapods', '~> 1.16'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'fastlane', '~> 2.232'

--- a/Bonni/Gemfile.lock
+++ b/Bonni/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.8)
+    abbrev (0.1.2)
     activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
@@ -19,7 +20,28 @@ GEM
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
+    artifactory (3.0.17)
     atomos (0.1.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1267.0)
+    aws-sdk-core (3.252.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.129.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.226.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    babosa (1.0.4)
     base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (4.1.2)
@@ -61,14 +83,107 @@ GEM
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
+    colored (1.2)
     colored2 (3.1.2)
+    commander (4.6.0)
+      highline (~> 2.0.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    csv (3.3.5)
+    declarative (0.0.20)
+    digest-crc (0.7.0)
+      rake (>= 12.0.0, < 14.0.0)
+    domain_name (0.6.20240107)
+    dotenv (2.8.1)
     drb (2.2.3)
+    emoji_regex (3.2.3)
     escape (0.0.4)
     ethon (0.18.0)
       ffi (>= 1.15.0)
       logger
+    excon (1.5.0)
+      logger
+    faraday (1.10.6)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-cookie_jar (0.0.8)
+      faraday (>= 0.8.0)
+      http-cookie (>= 1.0.0)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.1)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (1.0.2)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.4)
+    faraday_middleware (1.2.1)
+      faraday (~> 1.0)
+    fastimage (2.4.1)
+    fastlane (2.237.0)
+      CFPropertyList (>= 2.3, < 5.0.0)
+      abbrev (~> 0.1)
+      addressable (>= 2.9.0, < 3.0.0)
+      artifactory (~> 3.0)
+      aws-sdk-s3 (~> 1.197)
+      babosa (>= 1.0.3, < 2.0.0)
+      base64 (~> 0.2)
+      benchmark (>= 0.1.0)
+      bundler (>= 2.4.0, < 5.0.0)
+      colored (~> 1.2)
+      commander (~> 4.6)
+      csv (~> 3.3)
+      dotenv (>= 2.1.1, < 3.0.0)
+      emoji_regex (>= 0.1, < 4.0)
+      excon (>= 0.71.0, < 2.0.0)
+      faraday (~> 1.0)
+      faraday-cookie_jar (~> 0.0.6)
+      faraday_middleware (~> 1.0)
+      fastimage (>= 2.1.0, < 3.0.0)
+      fastlane-sirp (>= 1.1.0)
+      gh_inspector (>= 1.1.2, < 2.0.0)
+      google-apis-androidpublisher_v3 (~> 0.3)
+      google-apis-playcustomapp_v1 (~> 0.1)
+      google-cloud-env (>= 1.6.0, < 2.3.0)
+      google-cloud-storage (~> 1.31)
+      highline (~> 2.0)
+      http-cookie (~> 1.0.5)
+      json (< 3.0.0)
+      jwt (>= 2.10.3, < 4)
+      logger (>= 1.6, < 2.0)
+      mini_magick (>= 4.9.4, < 5.0.0)
+      multi_json (~> 1.12)
+      multipart-post (>= 2.0.0, < 3.0.0)
+      mutex_m (~> 0.3)
+      naturally (~> 2.2)
+      nkf (~> 0.2)
+      optparse (>= 0.1.1, < 1.0.0)
+      ostruct (>= 0.1.0)
+      plist (>= 3.1.0, < 4.0.0)
+      rubyzip (>= 2.0.0, < 3.0.0)
+      security (= 0.1.5)
+      simctl (~> 1.6.3)
+      terminal-notifier (>= 2.0.0, < 3.0.0)
+      terminal-table (~> 3)
+      tty-screen (>= 0.6.3, < 1.0.0)
+      tty-spinner (>= 0.8.0, < 1.0.0)
+      word_wrap (~> 1.0.0)
+      xcodeproj (>= 1.13.0, < 2.0.0)
+      xcpretty (~> 0.4.1)
+      xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-sirp (1.1.0)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
@@ -83,26 +198,112 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
+    google-apis-androidpublisher_v3 (0.104.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-core (0.18.0)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (~> 1.9)
+      httpclient (>= 2.8.3, < 3.a)
+      mini_mime (~> 1.0)
+      mutex_m
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.a)
+    google-apis-iamcredentials_v1 (0.28.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-playcustomapp_v1 (0.18.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-storage_v1 (0.64.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-cloud-core (1.9.0)
+      google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-env (2.2.2)
+      base64 (~> 0.2)
+      faraday (>= 1.0, < 3.a)
+    google-cloud-errors (1.6.0)
+    google-cloud-storage (1.62.0)
+      addressable (~> 2.8)
+      digest-crc (~> 0.4)
+      google-apis-core (>= 0.18, < 2)
+      google-apis-iamcredentials_v1 (~> 0.18)
+      google-apis-storage_v1 (>= 0.42)
+      google-cloud-core (~> 1.6)
+      googleauth (~> 1.9)
+      mini_mime (~> 1.0)
+    google-logging-utils (0.2.0)
+    googleauth (1.17.1)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      jwt (>= 1.4, < 4.0)
+      os (>= 0.9, < 2.0)
+      pstore (~> 0.1)
+      signet (>= 0.16, < 2.a)
+    highline (2.0.3)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
     json (2.19.5)
+    jwt (3.2.0)
+      base64
     logger (1.7.0)
+    mini_magick (4.13.2)
+    mini_mime (1.1.5)
     minitest (5.27.0)
     molinillo (0.8.0)
+    multi_json (1.21.1)
+    multipart-post (2.4.1)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     nap (1.1.0)
+    naturally (2.3.0)
     netrc (0.11.0)
+    nkf (0.3.0)
+    optparse (0.8.1)
+    os (1.1.4)
+    ostruct (0.6.3)
+    plist (3.7.2)
+    pstore (0.2.1)
     public_suffix (4.0.7)
+    rake (13.4.2)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.8.0)
     rexml (3.4.4)
+    rouge (3.28.0)
     ruby-macho (2.5.1)
+    ruby2_keywords (0.0.5)
+    rubyzip (2.4.1)
     securerandom (0.4.1)
+    security (0.1.5)
+    signet (0.22.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 4.0)
+    simctl (1.6.10)
+      CFPropertyList
+      naturally
+    terminal-notifier (2.0.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    trailblazer-option (0.1.2)
+    tty-cursor (0.7.1)
+    tty-screen (0.8.2)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
     typhoeus (1.6.0)
       ethon (>= 0.18.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uber (0.1.0)
+    unicode-display_width (2.6.0)
+    word_wrap (1.0.0)
     xcodeproj (1.27.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -110,6 +311,10 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.4.0)
       rexml (>= 3.3.6, < 4.0)
+    xcpretty (0.4.1)
+      rouge (~> 3.28.0)
+    xcpretty-travis-formatter (1.0.1)
+      xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -127,13 +332,23 @@ PLATFORMS
 DEPENDENCIES
   activesupport (>= 6.1.7.5, != 7.1.0)
   cocoapods (~> 1.16)
+  fastlane (~> 2.232)
 
 CHECKSUMS
   CFPropertyList (3.0.8) sha256=2c99d0d980536d3d7ab252f7bd59ac8be50fbdd1ff487c98c949bb66bb114261
+  abbrev (0.1.2) sha256=ad1b4eaaaed4cb722d5684d63949e4bde1d34f2a95e20db93aecfe7cbac74242
   activesupport (7.2.3.1) sha256=11ebed516a43a0bb47346227a35ebae4d9427465a7c9eb197a03d5c8d283cb34
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   algoliasearch (1.27.5) sha256=26c1cddf3c2ec4bd60c148389e42702c98fdac862881dc6b07a4c0b89ffec853
+  artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
+  aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
+  aws-partitions (1.1267.0) sha256=15a4c6bef8c303b09a1452c675cecb1ace0238dc91e26fe4646c5d761cb2221e
+  aws-sdk-core (3.252.0) sha256=09c042cbfc2acf2239441cc9b982ebab2a999bed2ef6bdc51849e7b3d6e48a1c
+  aws-sdk-kms (1.129.0) sha256=363f548df321f4a4fcfd05523384e591060b400f8e65133ed7ef0793155a3343
+  aws-sdk-s3 (1.226.0) sha256=e599f431e006ec9b92c61ee0f14d3f658a1f6c8a1d623d2160be927ac958e2bf
+  aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
+  babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
@@ -147,12 +362,37 @@ CHECKSUMS
   cocoapods-search (1.0.1) sha256=1b133b0e6719ed439bd840e84a1828cca46425ab73a11eff5e096c3b2df05589
   cocoapods-trunk (1.6.0) sha256=5f5bda8c172afead48fa2d43a718cf534b1313c367ba1194cebdeb9bfee9ed31
   cocoapods-try (1.2.0) sha256=145b946c6e7747ed0301d975165157951153d27469e6b2763c83e25c84b9defe
+  colored (1.2) sha256=9d82b47ac589ce7f6cab64b1f194a2009e9fd00c326a5357321f44afab2c1d2c
   colored2 (3.1.2) sha256=b13c2bd7eeae2cf7356a62501d398e72fde78780bd26aec6a979578293c28b4a
+  commander (4.6.0) sha256=7d1ddc3fccae60cc906b4131b916107e2ef0108858f485fdda30610c0f2913d9
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
+  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
+  domain_name (0.6.20240107) sha256=5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933
+  dotenv (2.8.1) sha256=c5944793349ae03c432e1780a2ca929d60b88c7d14d52d630db0508c3a8a17d8
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  emoji_regex (3.2.3) sha256=ecd8be856b7691406c6bf3bb3a5e55d6ed683ffab98b4aa531bb90e1ddcc564b
   escape (0.0.4) sha256=e49f44ae2b4f47c6a3abd544ae77fe4157802794e32f19b8e773cbc4dcec4169
   ethon (0.18.0) sha256=b598afc9f30448cb068b850714b7d6948e941476095d04f90a4ac65b8d6efcb2
+  excon (1.5.0) sha256=c503ad1d0123bc8ab2a062ff3789dc891ec368cb9e13765ab88a9c58c8bb6d50
+  faraday (1.10.6) sha256=7ff4802a6b312876a2241b3e641ce0d5045e168dd871b422c35b505e5261ad4d
+  faraday-cookie_jar (0.0.8) sha256=0140605823f8cc63c7028fccee486aaed8e54835c360cffc1f7c8c07c4299dbb
+  faraday-em_http (1.0.0) sha256=7a3d4c7079789121054f57e08cd4ef7e40ad1549b63101f38c7093a9d6c59689
+  faraday-em_synchrony (1.0.1) sha256=bf3ce45dcf543088d319ab051f80985ea6d294930635b7a0b966563179f81750
+  faraday-excon (1.1.0) sha256=b055c842376734d7f74350fe8611542ae2000c5387348d9ba9708109d6e40940
+  faraday-httpclient (1.0.1) sha256=4c8ff1f0973ff835be8d043ef16aaf54f47f25b7578f6d916deee8399a04d33b
+  faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
+  faraday-net_http (1.0.2) sha256=63992efea42c925a20818cf3c0830947948541fdcf345842755510d266e4c682
+  faraday-net_http_persistent (1.2.0) sha256=0b0cbc8f03dab943c3e1cc58d8b7beb142d9df068b39c718cd83e39260348335
+  faraday-patron (1.0.0) sha256=dc2cd7b340bb3cc8e36bcb9e6e7eff43d134b6d526d5f3429c7a7680ddd38fa7
+  faraday-rack (1.0.0) sha256=ef60ec969a2bb95b8dbf24400155aee64a00fc8ba6c6a4d3968562bcc92328c0
+  faraday-retry (1.0.4) sha256=dc659233777fabf96c69c2ffe56c0a5d2c102af90321a42cc6c90157bcd716aa
+  faraday_middleware (1.2.1) sha256=d45b78c8ee864c4783fbc276f845243d4a7918a67301c052647bacabec0529e9
+  fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
+  fastlane (2.237.0) sha256=bb1e867bc070fb328741b5e6e7606d5ba596941a9ecca0478f60ef22d1009db9
+  fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
@@ -167,23 +407,69 @@ CHECKSUMS
   fourflusher (2.3.1) sha256=1b3de61c7c791b6a4e64f31e3719eb25203d151746bb519a0292bff1065ccaa9
   fuzzy_match (2.0.4) sha256=b5de4f95816589c5b5c3ad13770c0af539b75131c158135b3f3bbba75d0cfca5
   gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
+  google-apis-androidpublisher_v3 (0.104.0) sha256=3bf7f0dee23ae71e070e279848374834853204e304831cf6aa76fa435a4d6eff
+  google-apis-core (0.18.0) sha256=96b057816feeeab448139ed5b5c78eab7fc2a9d8958f0fbc8217dedffad054ee
+  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
+  google-apis-playcustomapp_v1 (0.18.0) sha256=44b277b9dee4a59ac5e9d98be1485edc5e382d2f9d73c79ae8908a455786a254
+  google-apis-storage_v1 (0.64.0) sha256=75b11afa2edcee859b84c7a6972ee4456314eeef5f762827fd6cf5c5ffaf93f2
+  google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
+  google-cloud-env (2.2.2) sha256=94bed40e05a67e9468ce1cb38389fba9a90aa8fc62fc9e173204c1dca59e21e7
+  google-cloud-errors (1.6.0) sha256=1da8476dd706ad04b9d32e3c4b90d07d3463b37d6407cb56d41342ea7647d0a1
+  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
+  google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
+  googleauth (1.17.1) sha256=0f7e6fc70e204cee1b2d71f1e1de2d3b349d432404197fe68ebf7fa23d0821b9
+  highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
+  http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
+  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   molinillo (0.8.0) sha256=efbff2716324e2a30bccd3eba1ff3a735f4d5d53ffddbc6a2f32c0ca9433045d
+  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   nanaimo (0.4.0) sha256=faf069551bab17f15169c1f74a1c73c220657e71b6e900919897a10d991d0723
   nap (1.1.0) sha256=949691660f9d041d75be611bb2a8d2fd559c467537deac241f4097d9b5eea576
+  naturally (2.3.0) sha256=459923cf76c2e6613048301742363200c3c7e4904c324097d54a67401e179e01
   netrc (0.11.0) sha256=de1ce33da8c99ab1d97871726cba75151113f117146becbe45aa85cb3dabee3f
+  nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
+  optparse (0.8.1) sha256=42bea10d53907ccff4f080a69991441d611fbf8733b60ed1ce9ee365ce03bd1a
+  os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+  plist (3.7.2) sha256=d37a4527cc1116064393df4b40e1dbbc94c65fa9ca2eec52edf9a13616718a42
+  pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (4.0.7) sha256=8be161e2421f8d45b0098c042c06486789731ea93dc3a896d30554ee38b573b8
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
+  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (3.28.0) sha256=0d6de482c7624000d92697772ab14e48dca35629f8ddf3f4b21c99183fd70e20
   ruby-macho (2.5.1) sha256=9075e52e0f9270b552a90b24fcc6219ad149b0d15eae1bc364ecd0ac8984f5c9
+  ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
+  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  security (0.1.5) sha256=3a977a0eca7706e804c96db0dd9619e0a94969fe3aac9680fcfc2bf9b8a833b7
+  signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
+  simctl (1.6.10) sha256=b99077f4d13ad81eace9f86bf5ba4df1b0b893a4d1b368bd3ed59b5b27f9236b
+  terminal-notifier (2.0.0) sha256=7a0d2b2212ab9835c07f4b2e22a94cff64149dba1eed203c04835f7991078cea
+  terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
+  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
+  tty-cursor (0.7.1) sha256=79534185e6a777888d88628b14b6a1fdf5154a603f285f80b1753e1908e0bf48
+  tty-screen (0.8.2) sha256=c090652115beae764336c28802d633f204fb84da93c6a968aa5d8e319e819b50
+  tty-spinner (0.9.3) sha256=0e036f047b4ffb61f2aa45f5a770ec00b4d04130531558a94bfc5b192b570542
   typhoeus (1.6.0) sha256=bacc41c23e379547e29801dc235cd1699b70b955a1ba3d32b2b877aa844c331d
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+  word_wrap (1.0.0) sha256=f556d4224c812e371000f12a6ee8102e0daa724a314c3f246afaad76d82accc7
   xcodeproj (1.27.0) sha256=8cc7a73b4505c227deab044dce118ede787041c702bc47636856a2e566f854d3
+  xcpretty (0.4.1) sha256=b14c50e721f6589ee3d6f5353e2c2cfcd8541fa1ea16d6c602807dd7327f3892
+  xcpretty-travis-formatter (1.0.1) sha256=aacc332f17cb7b2cba222994e2adc74223db88724fe76341483ad3098e232f93
 
 RUBY VERSION
   ruby 3.3.11

--- a/Bonni/android/app/build.gradle
+++ b/Bonni/android/app/build.gradle
@@ -80,7 +80,7 @@ android {
 
     namespace "com.bonni"
     defaultConfig {
-        applicationId "com.attentive.bonni"
+        applicationId "com.attentive.rn.example.Bonni"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
@@ -93,15 +93,27 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        // Release signing for Firebase App Distribution. In CI the keystore is
+        // base64-decoded to bonni-release.keystore and the BONNI_* env vars are set
+        // (mirrors the native Android SDK). Locally these are absent, and release
+        // falls back to the debug key (see buildTypes.release) so `gen-apk` still works.
+        release {
+            if (System.getenv("BONNI_STORE_PASSWORD") != null) {
+                storeFile file('bonni-release.keystore')
+                storePassword System.getenv("BONNI_STORE_PASSWORD")
+                keyAlias System.getenv("BONNI_KEY_ALIAS")
+                keyPassword System.getenv("BONNI_KEY_PASSWORD")
+            }
+        }
     }
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
         }
         release {
-            // Caution! In production, you need to generate your own keystore file.
-            // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            // Sign with the release keystore when the BONNI_* env vars are present (CI);
+            // otherwise fall back to the debug key so local `npm run gen-apk` still works.
+            signingConfig System.getenv("BONNI_STORE_PASSWORD") != null ? signingConfigs.release : signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }

--- a/Bonni/ios/Bonni.xcodeproj/project.pbxproj
+++ b/Bonni/ios/Bonni.xcodeproj/project.pbxproj
@@ -317,7 +317,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Bonni/Bonni.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -338,7 +337,6 @@
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.attentive.rn.example.Bonni;
 				PRODUCT_NAME = Bonni;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Bonni-RN-App-Distribution";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Bonni/Bonni-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Bonni/ios/fastlane/Appfile
+++ b/Bonni/ios/fastlane/Appfile
@@ -1,0 +1,1 @@
+app_identifier("com.attentive.rn.example.Bonni")

--- a/Bonni/ios/fastlane/Fastfile
+++ b/Bonni/ios/fastlane/Fastfile
@@ -28,6 +28,12 @@ def api_key
   )
 end
 
+# On CI, create a temporary keychain for match. Without this, match imports the App Store
+# cert into the locked login keychain and fails with "User interaction is not allowed".
+before_all do
+  setup_circle_ci if is_ci
+end
+
 platform :ios do
   desc "Build the Bonni app for App Store (TestFlight): match signing + ASC build number + export IPA"
   lane :build_bonni_release do
@@ -42,7 +48,8 @@ platform :ios do
     latest_build = app_store_build_number(
       live: false,
       api_key: api_key,
-      app_identifier: APP_IDENTIFIER
+      app_identifier: APP_IDENTIFIER,
+      initial_build_number: 0
     )
     increment_build_number(
       build_number: latest_build + 1,
@@ -55,6 +62,7 @@ platform :ios do
       use_automatic_signing: false,
       path: XCODEPROJ,
       targets: [SCHEME],
+      build_configurations: ["Release"],
       profile_name: profile_name,
       code_sign_identity: "Apple Distribution"
     )

--- a/Bonni/ios/fastlane/Fastfile
+++ b/Bonni/ios/fastlane/Fastfile
@@ -1,0 +1,89 @@
+# Bonni (React Native demo app) — iOS TestFlight distribution.
+#
+# Mirrors the attentive-ios-sdk `build_bonni_release` + `deploy_testflight` lanes, adapted for
+# the RN Bonni: a single app target (no notification-service extension) with bundle id
+# com.attentive.rn.example.Bonni, built from the CocoaPods workspace. Code signing is handled
+# by fastlane match (shared S3 repo); App Store Connect auth is via an API key.
+#
+# The React Native prerequisites (root `npm ci` + `npm run build` to produce the SDK's lib/,
+# Bonni `npm ci`, and `pod install`) are done by the CircleCI job before these lanes run.
+
+default_platform(:ios)
+
+APP_IDENTIFIER = "com.attentive.rn.example.Bonni".freeze
+SCHEME = "Bonni".freeze
+WORKSPACE = "Bonni.xcworkspace".freeze
+XCODEPROJ = "Bonni.xcodeproj".freeze
+BUILD_OUTPUT_DIR = ENV["FASTLANE_BUILD_OUTPUT_DIR"] || "build".freeze
+IPA_PATH = "#{BUILD_OUTPUT_DIR}/#{SCHEME}.ipa".freeze
+
+# App Store Connect API key (shared with the native iOS SDK's org-global context).
+# APP_STORE_CONNECT_API_KEY_CONTENT is the base64-encoded .p8.
+def api_key
+  app_store_connect_api_key(
+    key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
+    issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
+    key_content: ENV["APP_STORE_CONNECT_API_KEY_CONTENT"],
+    is_key_content_base64: true
+  )
+end
+
+platform :ios do
+  desc "Build the Bonni app for App Store (TestFlight): match signing + ASC build number + export IPA"
+  lane :build_bonni_release do
+    # Fetch the App Store distribution cert + provisioning profile from the shared match S3 repo.
+    sync_code_signing(
+      type: "appstore",
+      readonly: true,
+      app_identifier: [APP_IDENTIFIER]
+    )
+
+    # Monotonically increasing TestFlight build number: latest on App Store Connect + 1.
+    latest_build = app_store_build_number(
+      live: false,
+      api_key: api_key,
+      app_identifier: APP_IDENTIFIER
+    )
+    increment_build_number(
+      build_number: latest_build + 1,
+      xcodeproj: XCODEPROJ
+    )
+
+    # match exports the resolved profile name as sigh_<bundle-id>_<type>_profile-name.
+    profile_name = ENV["sigh_#{APP_IDENTIFIER}_appstore_profile-name"]
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: XCODEPROJ,
+      targets: [SCHEME],
+      profile_name: profile_name,
+      code_sign_identity: "Apple Distribution"
+    )
+
+    build_ios_app(
+      workspace: WORKSPACE,
+      scheme: SCHEME,
+      configuration: "Release",
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: { APP_IDENTIFIER => profile_name }
+      },
+      output_directory: BUILD_OUTPUT_DIR,
+      output_name: "#{SCHEME}.ipa",
+      clean: true
+    )
+  end
+
+  desc "Upload the built Bonni IPA to TestFlight (internal testers only)"
+  lane :deploy_testflight do
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: IPA_PATH,
+      distribute_external: false,
+      notify_external_testers: false
+    )
+
+    # Export the build number so the CircleCI Slack success step can reference it.
+    build_number = get_ipa_info_plist_value(ipa: IPA_PATH, key: "CFBundleVersion")
+    sh("echo 'export TESTFLIGHT_BUILD_NUMBER=#{build_number}' >> \"$BASH_ENV\"") if build_number
+  end
+end

--- a/Bonni/ios/fastlane/Matchfile
+++ b/Bonni/ios/fastlane/Matchfile
@@ -1,0 +1,14 @@
+# fastlane match — code signing for the Bonni (RN demo) app.
+# Reuses the shared Attentive S3 match repo (same bucket/prefix as the native iOS SDK), so
+# the App Store distribution certificate is shared; only the provisioning profile for this
+# app id is app-specific. Bucket/region come from the CircleCI org-global context.
+app_identifier(["com.attentive.rn.example.Bonni"])
+username(ENV.fetch("APPLE_ID"))
+team_id(ENV.fetch("APPLE_TEAM_ID"))
+
+type("appstore")
+
+storage_mode("s3")
+s3_bucket(ENV.fetch("MATCH_S3_BUCKET"))
+s3_region(ENV.fetch("MATCH_S3_REGION"))
+s3_object_prefix("ios/signing/")

--- a/Bonni/ios/fastlane/Matchfile
+++ b/Bonni/ios/fastlane/Matchfile
@@ -3,7 +3,6 @@
 # the App Store distribution certificate is shared; only the provisioning profile for this
 # app id is app-specific. Bucket/region come from the CircleCI org-global context.
 app_identifier(["com.attentive.rn.example.Bonni"])
-username(ENV.fetch("APPLE_ID"))
 team_id(ENV.fetch("APPLE_TEAM_ID"))
 
 type("appstore")

--- a/Bonni/package.json
+++ b/Bonni/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.2",
   "private": true,
   "scripts": {
-    "android-pure": "cd android && ./gradlew app:installDebug -PreactNativeDevServerPort=8081 && adb shell am start -n com.attentive.bonni/com.bonni.MainActivity",
-    "android-fresh": "npm --prefix .. run build && cd android && ./gradlew app:installDebug -PreactNativeDevServerPort=8081 && adb shell am start -n com.attentive.bonni/com.bonni.MainActivity",
+    "android-pure": "cd android && ./gradlew app:installDebug -PreactNativeDevServerPort=8081 && adb shell am start -n com.attentive.rn.example.Bonni/com.bonni.MainActivity",
+    "android-fresh": "npm --prefix .. run build && cd android && ./gradlew app:installDebug -PreactNativeDevServerPort=8081 && adb shell am start -n com.attentive.rn.example.Bonni/com.bonni.MainActivity",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "gen-apk": "cd android && ./gradlew :app:assembleRelease --rerun-tasks && find app/build/outputs/apk -type f -name \"*.apk\" -print0 | xargs -0 ls -lt | head -n 5 && cd ..",


### PR DESCRIPTION
## What

**Phase B — automate shipping the Bonni demo app to testers**, mirroring the native SDKs: **iOS → TestFlight** and **Android → Firebase App Distribution**. Follows the release-automation pipeline from #89 (Phase A). Tracked by **[MSDK-422](https://attentivemobile.atlassian.net/browse/MSDK-422)** (under the CI/CD epic MSDK-378).

Today Bonni builds are archived/uploaded to TestFlight by hand and Android APKs are shared via Google Drive; this makes both one-click.

## iOS → TestFlight
- `Bonni/ios/fastlane/` — `build_bonni_release` + `deploy_testflight` lanes (single target `com.attentive.rn.example.Bonni`, match signing on the shared S3 repo, ASC API key, build number auto-incremented from App Store Connect).
- `.circleci/config.yml` — `macos-xcode` executor + self-contained `deploy-bonni-testflight` job (App-token checkout → AWS OIDC → Node → `npm ci`/`npm run build` → Bonni deps → pods → fastlane build+upload) + `deploy-testflight` workflow.
- `.github/workflows/deploy-testflight.yml` — manual `workflow_dispatch` (branch input) → CircleCI. Skipped for prereleases; posts "✅ Bonni TestFlight Build Deployed" to `#eng-mobile-sdk-releases`.

## Android → Firebase App Distribution
- `Bonni/android/app/build.gradle` — `applicationId` → **`com.attentive.rn.example.Bonni`** (its own Firebase app — no longer collides with the native Android Bonni's `com.attentive.bonni`) + env-driven release `signingConfig` (debug-key fallback so local `gen-apk` still works).
- `.circleci/config.yml` — `android-executor` + `distribute-bonni-android` job (versionCode-change gate → decode keystore → `:app:assembleRelease` → `firebase appdistribution:distribute --app $FIREBASE_APP_ID --token $FIREBASE_TOKEN --groups "dev, product-+-eng"`), on `main` pushes only, reusing the `setup-bonni` workspace. Mirrors native Android exactly.
- Distributes to the existing `com.attentive.rn.example.Bonni` app (`1:692182507781:android:e3fff65a79d2c31c1f576c`) in `attentive-android-bonni-prod`.

## Prereqs before the first run
**Android** — RN-project CircleCI env vars (Tyler is adding): `FIREBASE_TOKEN`, `FIREBASE_APP_ID` (= the RN app id above), and the release keystore `BONNI_KEYSTORE_BASE64` / `BONNI_STORE_PASSWORD` / `BONNI_KEY_ALIAS` / `BONNI_KEY_PASSWORD`.
**iOS** — one-time `fastlane match appstore` registration for `com.attentive.rn.example.Bonni` (Apple-portal access); ASC API key / match S3 / AWS OIDC already in `org-global`; app already on TestFlight (ASC `6756636791`).

## Why draft
The native build/sign/upload steps (RN + pods/Hermes on Xcode 26 macOS for iOS; gradle release build + Firebase upload for Android) can't be validated without live CI runs + the credentials above — expect a couple of iterations, as with any pipeline bring-up. Locally validated: `circleci config validate` (private orb stubbed), `ruby -c` on the fastlane files, Gradle brace-balance, and YAML/JSON parse all pass.

## How to test (once creds land)
- **iOS:** Actions → Deploy TestFlight → Run workflow (branch `main`) → build lands in TestFlight (ASC `6756636791`).
- **Android:** bump the Bonni `versionCode` and push to `main` → `distribute-bonni-android` ships to the `dev` / `product-+-eng` Firebase groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MSDK-422]: https://attentivemobile.atlassian.net/browse/MSDK-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ