### PR TITLE
fix(bonni): stop Clear User button from calling clearUser() twice

### DIFF
--- a/Bonni/__tests__/SettingsScreen.test.tsx
+++ b/Bonni/__tests__/SettingsScreen.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Regression test for MSDK-406.
+ *
+ * The Settings screen's "Clear User" and "Log Out" buttons must each invoke the
+ * SDK's clearUser() exactly once per press. "Clear User" previously fired it
+ * twice — once via a direct SDK import and once via
+ * useAttentiveUser().clearUserIdentification() (which itself calls clearUser) —
+ * producing a duplicate user-update call and a double visitor-ID rotation.
+ *
+ * Both handlers reach clearUser() through the useAttentiveUser hook, so a
+ * call-count assertion is the cheapest guard against the "direct SDK call plus a
+ * hook that already calls the SDK" pattern re-landing (see PR #92 review).
+ *
+ * The SDK module is auto-mocked (jest replaces every export with a jest.fn())
+ * rather than hand-stubbed: SettingsScreen mounts six hooks that import ~a dozen
+ * SDK functions between them, and automock spares the test from tracking that
+ * list. (The narrower hook tests, e.g. useMarketingSubscriptions.test.ts, stub
+ * their two or three exports explicitly.)
+ */
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+import { Alert } from 'react-native'
+import * as sdk from '@attentive-mobile/attentive-react-native-sdk'
+import type { SettingsScreenProps } from '../src/types/navigation'
+
+jest.mock('@attentive-mobile/attentive-react-native-sdk')
+
+import SettingsScreen from '../src/screens/SettingsScreen'
+
+// SettingsScreen is typed with navigation props its body never reads at runtime,
+// so an empty cast satisfies the types without a NavigationContainer.
+const stubProps = {} as SettingsScreenProps
+
+describe('SettingsScreen — clearUser call count (MSDK-406)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // displayAlerts defaults to true, so both handlers fire Alert.alert — silence it.
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {})
+  })
+
+  it('calls SDK clearUser exactly once when "Clear User" is pressed', async () => {
+    const { findByText } = render(<SettingsScreen {...stubProps} />)
+
+    // Awaiting the query flushes the async AsyncStorage reads the screen kicks
+    // off on mount before we interact.
+    fireEvent.press(await findByText('Clear User'))
+
+    expect(sdk.clearUser).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls SDK clearUser exactly once when "Log Out" is pressed', async () => {
+    const { findByText } = render(<SettingsScreen {...stubProps} />)
+
+    fireEvent.press(await findByText('Log Out'))
+
+    expect(sdk.clearUser).toHaveBeenCalledTimes(1)
+  })
+})

--- a/Bonni/src/screens/SettingsScreen.tsx
+++ b/Bonni/src/screens/SettingsScreen.tsx
@@ -31,7 +31,6 @@ import { useSwitchUser } from '../hooks/useSwitchUser'
 import {
   registerForPushNotifications,
   registerDeviceToken,
-  clearUser as sdkClearUser,
 } from '@attentive-mobile/attentive-react-native-sdk'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import PushNotificationIOS from '@react-native-community/push-notification-ios'
@@ -347,8 +346,6 @@ The SDK will handle the API request internally.`
   }, [identifyUser, displayAlerts, showScreenPrompt])
 
   const handleClearUser = useCallback(() => {
-    // Call SDK's clearUser method
-    sdkClearUser()
     clearUserIdentification()
     setCurrentUser('Guest')
     if (displayAlerts) {


### PR DESCRIPTION
## Summary

The **Clear User** button in Bonni's Settings screen invoked the SDK's `clearUser()` **twice** on a single tap — producing a duplicate `POST /user-update` and a double visitor-ID rotation. The first new visitor ID receives a `user-update` and is then immediately superseded (~1 ms later), leaving an orphaned visitor.

This is a **Bonni reference-app bug only**. The SDK's `clearUser()` itself is correct (one call = one token detach + one visitor-ID rotation), so there is **no SDK change** here.

## Root cause

`handleClearUser` called `clearUser` through two paths back-to-back:

- `sdkClearUser()` — a direct SDK import (aliased)
- `clearUserIdentification()` — from the `useAttentiveUser` hook, which itself calls `clearUser()`

## Change

Remove the redundant direct `sdkClearUser()` call (and its now-unused import) so `handleClearUser` calls only `clearUserIdentification()` — matching the existing `handleLogOut` pattern. A regression test locks the behavior in (see Verification). Net: a 3-line handler deletion, no behavior change beyond firing `clearUser` exactly once.

## Verification

- `npm run lint` → 0 errors; `npm run typecheck` → clean; full Bonni suite green (34/34) (all from `Bonni/`).
- **Regression test included** (`Bonni/__tests__/SettingsScreen.test.tsx`): renders the screen and presses **Clear User** and **Log Out**, asserting the SDK's `clearUser()` fires exactly once per press. Confirmed it goes **red at 2 calls** if the duplicate is reintroduced and **green at 1** after the fix. Per PR review, a call-count assertion is the cheapest guard against the "direct SDK call plus a hook that already calls the SDK" pattern re-landing.
- Optional runtime check (mirrors the original bug evidence): build Bonni on Android, clear the logcat buffer, tap **Clear User** once → expect a single `POST …/user-update` and a single `Attentive: Resetting user identifiers with new visitor ID`.

## Ticket

[MSDK-406](https://attentivemobile.atlassian.net/browse/MSDK-406)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MSDK-406]: https://attentivemobile.atlassian.net/browse/MSDK-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
