### PR TITLE
chore(hooks): run pre-commit lint/type checks on fresh branches

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,22 +1,21 @@
+# File lists use the built-in {staged_files} template rather than a custom
+# `git diff … @{push}` command: @{push} fails (git exit 128) on a fresh branch
+# with no upstream configured, which made lefthook silently skip every hook.
 pre-commit:
   parallel: true
   commands:
     lint-sdk:
-      files: git diff --name-only @{push}
       glob: "*.{js,ts,jsx,tsx}"
       exclude: "(Bonni|example)/.*"
-      run: npx eslint --no-cache {files}
+      run: npx eslint --no-cache {staged_files}
     types-sdk:
-      files: git diff --name-only @{push}
-      glob: "*.{js,ts, jsx, tsx}"
+      glob: "*.{js,ts,jsx,tsx}"
       exclude: "(Bonni|example)/.*"
       run: npx tsc --noEmit
     lint-bonni:
-      files: git diff --name-only @{push}
       glob: "Bonni/**/*.{js,ts,jsx,tsx}"
       run: cd Bonni && npx eslint --no-cache .
     types-bonni:
-      files: git diff --name-only @{push}
       glob: "Bonni/**/*.{js,ts,jsx,tsx}"
       run: cd Bonni && npx tsc --noEmit
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,13 @@
 # File lists use the built-in {staged_files} template rather than a custom
 # `git diff … @{push}` command: @{push} fails (git exit 128) on a fresh branch
 # with no upstream configured, which made lefthook silently skip every hook.
+#
+# Gate vs. scope: each command's glob/exclude only decides WHETHER the hook
+# fires for a given staged-file set — not what gets checked. Only lint-sdk pipes
+# {staged_files} into eslint to scope it; types-sdk/types-bonni (tsc --noEmit)
+# and lint-bonni (eslint .) always run project-wide, so for those the
+# glob/exclude are a gate, not a file filter. Full-branch coverage is CI's job
+# (.circleci/config.yml runs eslint on the SDK and Bonni on push).
 pre-commit:
   parallel: true
   commands:


### PR DESCRIPTION
## Problem

Every `pre-commit` command in `lefthook.yml` built its file list with:

```yaml
files: git diff --name-only @{push}
```

`@{push}` resolves to the branch's configured push remote. On any **freshly-created local branch with no upstream**, `@{push}` is unresolvable and git exits **128**. Lefthook then can't expand `{files}`, prints `error replacing {files}: exit status 128`, and **silently skips every hook** (`SUMMARY: (SKIP EMPTY)`).

Net effect: lint and type checks **never run on a new branch** until it's pushed and has a tracking ref — precisely the checks you'd want on a fresh feature branch don't run, with no obvious signal that they were skipped.

## Fix

- Drop the `files: git diff … @{push}` source from all four commands and use lefthook's built-in **`{staged_files}`** template, which needs no upstream (the conventional pre-commit file source).
- Fix the `types-sdk` glob: `"*.{js,ts, jsx, tsx}"` had spaces inside the brace list, so it never matched `.jsx`/`.tsx` files. Now `"*.{js,ts,jsx,tsx}"`.

**Tradeoff:** pre-commit now inspects the files staged for *this* commit rather than everything in the outgoing push — standard pre-commit behavior; full-branch coverage belongs in CI. In practice the scope barely changes: `types-*` run `tsc --noEmit` over the whole project regardless, and `lint-bonni` runs `eslint .` over all of Bonni; only `lint-sdk`'s eslint scope narrows to staged files. That branch-level coverage is the safety net in CI — `.circleci/config.yml` runs ESLint on the SDK (`npm run lint`, L119–120) and on Bonni (L187) on every push — so anything a narrower pre-commit misses is still caught before merge.

> **Note on the config's two knobs (per review):** each command's `glob`/`exclude` only gates *whether* the hook fires for a staged-file set; *what* gets checked is set by the `run:` command itself (`{staged_files}` scopes eslint in `lint-sdk`; everything else runs project-wide). A comment block in `lefthook.yml` now documents this so future hook additions don't misread it.

## Verification

On a fresh branch with no upstream (the exact failing condition — this branch):

- **Before:** `npx lefthook run pre-commit` → `error replacing {files}: exit status 128` for every command → `SKIP EMPTY`.
- **After, `lefthook.yml` only staged:** hooks skip **gracefully** — `(skip) no matching staged files` / `no files for inspection`, no error.
- **After, a Bonni `.ts` file staged:** `lint-bonni` and `types-bonni` **run and pass** (✔️); the sdk hooks are correctly excluded.
- The commit in this PR was itself created on a fresh no-upstream branch, and its pre-commit hook ran without the 128 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
