### PR TITLE
docs: reorder README creative sections and add creatives hand-off to AGENTS.md (MSDK-431)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,14 @@ npx react-native run-android   # or build in Android Studio
    - `clearUser`, `updateDomain`, and marketing subscription helpers (`optInMarketingSubscription` / `optOutMarketingSubscription`) are exported from the package — see the API surface in [src/index.tsx](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/src/index.tsx) and the types in [src/eventTypes.tsx](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/src/eventTypes.tsx).
    ```
 
+3. After the block above, call out **Creatives** explicitly — do not let them get lost in that list. Creatives are the in-app sign-up units and messages Attentive renders over the host app, and they are a core part of the SDK. However, **when and where to trigger one is a domain-specific product decision** (which screen, which moment in the user journey), so the user must place that call themselves — your job is to surface the documentation, not to write the trigger. Emit this to the user, verbatim (same link rules as above):
+
+   ```
+   One follow-up worth prioritizing: Creatives — Attentive's in-app sign-up units and messages — are a core part of the SDK, and this integration intentionally did not wire them up. When and where to show one is specific to your app (e.g. after onboarding, on a first product view), so that decision is yours. Once you've picked the moment, see [Load the Creative](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md#load-the-creative) in the README — it's a single `triggerCreative()` call, plus [`destroyCreative()`](https://github.com/attentive-mobile/attentive-react-native-sdk/blob/main/README.md#destroy-the-creative) if you need to dismiss it programmatically.
+   ```
+
+   Do not add `triggerCreative()` calls yourself, even if an obvious spot presents itself — pointing the user to the docs is the entire task here.
+
 Do not run the app on a device or simulator unless asked.
 
 ---

--- a/README.md
+++ b/README.md
@@ -174,14 +174,6 @@ After the native initialization, all other SDK operations (`identify`, `recordAd
 
 > **Tip:** If you see `[AttentiveSDK] recordAddToCartEvent failed — SDK may not be initialized` in your Android logcat, it means `AttentiveSdk.initialize()` was not called from native code before the event was recorded. Check your `Application.onCreate()` setup.
 
-### Destroy the creative
-
-```typescript
-// This will remove the creative along with its web view
-destroyCreative();
-```
-
-
 ### Identify the current user
 
 Use `identify` to **add or enrich** information about the **current** user. As you gather identifiers (client user ID, email, phone, etc.), pass them to Attentive via `identify`. Each identifier is optional, and you can call `identify` repeatedly as you learn more about the user — **multiple calls combine the identifiers** rather than replacing them. The more identifiers you provide, the better the SDK functions.
@@ -244,6 +236,13 @@ try {
 ```typescript
 // Trigger the Creative. This will show the Creative as a pop-up over the rest of the app.
 triggerCreative();
+```
+
+### Destroy the creative
+
+```typescript
+// This will remove the creative along with its web view
+destroyCreative();
 ```
 
 ### Record user events


### PR DESCRIPTION
## Summary

Docs-only change, two parts ([MSDK-431](https://attentivemobile.atlassian.net/browse/MSDK-431)):

1. **README.md — fix creative section order.** "Destroy the creative" appeared before "Load the Creative" (with the identify/`updateUser` sections in between), which is backwards from how a consumer actually uses the API. "Destroy the creative" now sits immediately after "Load the Creative", so the Usage flow reads: Identify → Switch user → Load the Creative → Destroy the creative → Record user events. Section content is unchanged, so existing `#load-the-creative` / `#destroy-the-creative` anchors still resolve.

2. **AGENTS.md — surface creatives at agent hand-off.** Creatives are a core part of the SDK, but *when and where* to trigger one is a domain-specific product decision that belongs to the human integrator. Step 5 (Hand off) now has an explicit item instructing integration agents to call out creatives after base integration — emitting a verbatim block that points the user to the README's creatives docs — while reiterating that agents must not add `triggerCreative()` calls themselves. This stays consistent with the existing "Things NOT to do" list.

## Public API impact

None — no code changes.

## Verification

Markdown-only change; no runtime surface on either platform or any RN version. Verified the AGENTS.md README anchors (`#load-the-creative`, `#destroy-the-creative`) are unchanged by the reorder.

## Host-app rollback

N/A — documentation only, nothing ships to host apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-431]: https://attentivemobile.atlassian.net/browse/MSDK-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ