### PR TITLE
chore(bonni): enforce Prettier via ESLint and format to match the SDK (MSDK-427)

### DIFF
--- a/Bonni/.eslintrc.js
+++ b/Bonni/.eslintrc.js
@@ -1,7 +1,9 @@
 module.exports = {
   root: true,
-  extends: '@react-native',
-  rules: {
-    'semi': ['error', 'never'],
-  },
+  // 'plugin:prettier/recommended' wires eslint-plugin-prettier so `eslint`
+  // reports Prettier violations as errors (reading .prettierrc.js), and applies
+  // eslint-config-prettier to disable ESLint's conflicting formatting rules.
+  // This mirrors the SDK's root eslintConfig; no separate prettier --check needed.
+  // (Prettier now owns semicolons, so the old `semi` rule is dropped.)
+  extends: ['@react-native', 'plugin:prettier/recommended'],
 }

--- a/Bonni/.prettierrc.js
+++ b/Bonni/.prettierrc.js
@@ -1,8 +1,11 @@
+// Mirrors the SDK's root Prettier config (the "prettier" field in the repo-root
+// package.json) so Bonni and the published SDK format identically. Keep in sync
+// with the root config.
 module.exports = {
-  arrowParens: 'avoid',
-  bracketSameLine: true,
-  bracketSpacing: false,
+  quoteProps: 'consistent',
   singleQuote: true,
-  trailingComma: 'all',
+  tabWidth: 2,
+  trailingComma: 'es5',
+  useTabs: false,
   semi: false,
-};
+}

--- a/Bonni/App.tsx
+++ b/Bonni/App.tsx
@@ -4,8 +4,17 @@
  */
 
 import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { StatusBar, Platform, AppState, NativeEventEmitter, NativeModules } from 'react-native'
-import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native'
+import {
+  StatusBar,
+  Platform,
+  AppState,
+  NativeEventEmitter,
+  NativeModules,
+} from 'react-native'
+import {
+  NavigationContainer,
+  useNavigationContainerRef,
+} from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import {
@@ -21,7 +30,9 @@ import {
   type PushAuthorizationStatus,
   type PushNotificationUserInfo,
 } from '../src'
-import PushNotificationIOS, { PushNotification } from '@react-native-community/push-notification-ios'
+import PushNotificationIOS, {
+  PushNotification,
+} from '@react-native-community/push-notification-ios'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
 import { CartProvider } from './src/models/CartContext'
@@ -53,16 +64,21 @@ const SCREENS_WITHOUT_HEADER: Record<string, string> = {
 function App(): React.JSX.Element {
   const navigationRef = useNavigationContainerRef<RootStackParamList>()
   // Initialize with transparent since Login is the initial route
-  const [statusBarBackgroundColor, setStatusBarBackgroundColor] = useState<string>('transparent')
+  const [statusBarBackgroundColor, setStatusBarBackgroundColor] =
+    useState<string>('transparent')
   const appStateRef = useRef<string>(AppState.currentState)
-  const lastKnownAndroidAuthStatusRef = useRef<PushAuthorizationStatus | null>(null)
-  const androidPermissionPollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const lastKnownAndroidAuthStatusRef = useRef<PushAuthorizationStatus | null>(
+    null
+  )
+  const androidPermissionPollIntervalRef = useRef<ReturnType<
+    typeof setInterval
+  > | null>(null)
   const hasTriggeredAndroidPostPromptRegistrationRef = useRef<boolean>(false)
 
-  const getIosAuthorizationStatus = useCallback((): Promise<PushAuthorizationStatus> => {
-    return new Promise((resolve) => {
-      PushNotificationIOS.checkPermissions(
-        (permissions) => {
+  const getIosAuthorizationStatus =
+    useCallback((): Promise<PushAuthorizationStatus> => {
+      return new Promise((resolve) => {
+        PushNotificationIOS.checkPermissions((permissions) => {
           if (permissions.alert || permissions.badge || permissions.sound) {
             resolve('authorized')
             return
@@ -71,26 +87,27 @@ function App(): React.JSX.Element {
           // checkPermissions does not expose "notDetermined" vs "denied", keep the current
           // app behavior and treat no enabled notification permissions as denied.
           resolve('denied')
-        },
-      )
-    })
-  }, [])
+        })
+      })
+    }, [])
 
-  const getCurrentAuthorizationStatus = useCallback(async (): Promise<PushAuthorizationStatus> => {
-    if (Platform.OS === 'ios') {
-      return getIosAuthorizationStatus()
-    }
+  const getCurrentAuthorizationStatus =
+    useCallback(async (): Promise<PushAuthorizationStatus> => {
+      if (Platform.OS === 'ios') {
+        return getIosAuthorizationStatus()
+      }
 
-    try {
-      return await getPushAuthorizationStatus()
-    } catch (error) {
-      console.warn('[Attentive] getPushAuthorizationStatus failed:', error)
-      return 'authorized'
-    }
-  }, [getIosAuthorizationStatus])
+      try {
+        return await getPushAuthorizationStatus()
+      } catch (error) {
+        console.warn('[Attentive] getPushAuthorizationStatus failed:', error)
+        return 'authorized'
+      }
+    }, [getIosAuthorizationStatus])
 
   const trackRegularOpen = useCallback(async () => {
-    const authStatus: PushAuthorizationStatus = await getCurrentAuthorizationStatus()
+    const authStatus: PushAuthorizationStatus =
+      await getCurrentAuthorizationStatus()
     console.log('[Attentive] Calling handleRegularOpen for app open tracking')
     console.log('   Authorization status:', authStatus)
     handleRegularOpen(authStatus)
@@ -103,7 +120,7 @@ function App(): React.JSX.Element {
 
     hasTriggeredAndroidPostPromptRegistrationRef.current = true
     console.log(
-      '[Attentive] Android push permission transitioned to authorized - re-registering token',
+      '[Attentive] Android push permission transitioned to authorized - re-registering token'
     )
     registerForPushNotifications()
   }, [])
@@ -125,12 +142,15 @@ function App(): React.JSX.Element {
       return
     }
 
-    const initialStatus: PushAuthorizationStatus = await getCurrentAuthorizationStatus()
+    const initialStatus: PushAuthorizationStatus =
+      await getCurrentAuthorizationStatus()
     if (initialStatus === 'authorized') {
       return
     }
 
-    console.log('[Attentive] Watching Android push permission result after prompt')
+    console.log(
+      '[Attentive] Watching Android push permission result after prompt'
+    )
     let attempts: number = 0
     const MAX_ATTEMPTS: number = 30
     const POLL_INTERVAL_MS: number = 500
@@ -149,7 +169,9 @@ function App(): React.JSX.Element {
           }
 
           if (attempts >= MAX_ATTEMPTS) {
-            console.log('[Attentive] Android permission watch timed out without authorization')
+            console.log(
+              '[Attentive] Android permission watch timed out without authorization'
+            )
             clearAndroidPermissionPoll()
           }
         })
@@ -168,12 +190,16 @@ function App(): React.JSX.Element {
 
   const registerPushAndTrackRegularOpen = useCallback(async () => {
     if (Platform.OS === 'ios') {
-      console.log('📱 [Attentive] Checking for existing device token before requesting permissions')
+      console.log(
+        '📱 [Attentive] Checking for existing device token before requesting permissions'
+      )
       PushNotificationIOS.checkPermissions((permissions) => {
         console.log('🔍 [Attentive] Current permissions:', permissions)
 
         if (permissions.alert || permissions.badge || permissions.sound) {
-          console.log('✅ [Attentive] Permissions already granted, attempting to get token')
+          console.log(
+            '✅ [Attentive] Permissions already granted, attempting to get token'
+          )
           PushNotificationIOS.requestPermissions()
           return
         }
@@ -186,7 +212,8 @@ function App(): React.JSX.Element {
     }
 
     console.log('📱 [Attentive] Registering Android push token via native SDK')
-    const currentAuthStatus: PushAuthorizationStatus = await getCurrentAuthorizationStatus()
+    const currentAuthStatus: PushAuthorizationStatus =
+      await getCurrentAuthorizationStatus()
     lastKnownAndroidAuthStatusRef.current = currentAuthStatus
     registerForPushNotifications()
     await watchAndroidPermissionPromptResolution()
@@ -217,20 +244,28 @@ function App(): React.JSX.Element {
       clientUserId: 'APP_USER_ID',
       shopifyId: '207119551',
       klaviyoId: '555555',
-      customIdentifiers: { customId: 'customIdValue' }, 
+      customIdentifiers: { customId: 'customIdValue' },
     })
     console.log('✅ [Attentive] User identified')
 
     // Defer first app open event so native SDK has time to apply identity and send to mobile.attentivemobile.com.
     // Without this delay, handleRegularOpen can run before identify() is processed and no request may be sent.
     const INITIAL_APP_OPEN_DELAY_MS = 300
-    console.log('⏳ [Attentive] Scheduling initial handleRegularOpen in', INITIAL_APP_OPEN_DELAY_MS, 'ms')
+    console.log(
+      '⏳ [Attentive] Scheduling initial handleRegularOpen in',
+      INITIAL_APP_OPEN_DELAY_MS,
+      'ms'
+    )
     const initialOpenTimer = setTimeout(async () => {
-      console.log('🌉 [Attentive] Triggering initial handleRegularOpen (app open / mtctrl)')
+      console.log(
+        '🌉 [Attentive] Triggering initial handleRegularOpen (app open / mtctrl)'
+      )
       try {
         await trackRegularOpen()
         console.log('✅ [Attentive] Initial handleRegularOpen completed')
-        console.log('   Check proxy for requests to mobile.attentivemobile.com (mtctrl, push registration)')
+        console.log(
+          '   Check proxy for requests to mobile.attentivemobile.com (mtctrl, push registration)'
+        )
       } catch (error) {
         console.error('❌ [Attentive] Error calling handleRegularOpen:', error)
       }
@@ -242,19 +277,27 @@ function App(): React.JSX.Element {
 
       // Setup event listeners first (but don't request permissions yet)
       setupPushNotifications()
-      console.log('✅ [Attentive] Push notification event listeners setup complete')
+      console.log(
+        '✅ [Attentive] Push notification event listeners setup complete'
+      )
 
       // Request permissions after a delay so the initial handleRegularOpen (above) can complete first
       console.log('⏳ [Attentive] Waiting 500ms before requesting permissions')
       setTimeout(() => {
         registerPushAndTrackRegularOpen().catch((error) => {
-          console.error('❌ [Attentive] iOS push registration flow failed:', error)
+          console.error(
+            '❌ [Attentive] iOS push registration flow failed:',
+            error
+          )
         })
       }, 500)
     } else if (Platform.OS === 'android') {
       console.log('📱 [Attentive] Setting up push notifications for Android')
       registerPushAndTrackRegularOpen().catch((error) => {
-        console.error('❌ [Attentive] Android push registration flow failed:', error)
+        console.error(
+          '❌ [Attentive] Android push registration flow failed:',
+          error
+        )
       })
       // TODO(MSDK-352): wire up killed-state push tap via getInitialPushNotification
     }
@@ -266,50 +309,90 @@ function App(): React.JSX.Element {
     let androidPushOpenedSubscription: { remove: () => void } | null = null
 
     if (Platform.OS === 'android') {
-      const attentiveEmitter = new NativeEventEmitter(NativeModules.AttentiveReactNativeSdk)
+      const attentiveEmitter = new NativeEventEmitter(
+        NativeModules.AttentiveReactNativeSdk
+      )
 
       // Persist the FCM token so the Settings screen can display and copy it,
       // mirroring the iOS flow where APNs delivers the token via the 'register' event.
       androidDeviceTokenSubscription = attentiveEmitter.addListener(
         'AttentiveDeviceToken',
         (token: string) => {
-          console.log('🎫 [Attentive] Android FCM token received:', token.substring(0, 16) + '...')
+          console.log(
+            '🎫 [Attentive] Android FCM token received:',
+            token.substring(0, 16) + '...'
+          )
           AsyncStorage.setItem('deviceToken', token)
-            .then(() => console.log('✅ [Attentive] Android device token stored in AsyncStorage'))
-            .catch((err) => console.error('❌ [Attentive] Failed to store Android device token:', err))
-        },
+            .then(() =>
+              console.log(
+                '✅ [Attentive] Android device token stored in AsyncStorage'
+              )
+            )
+            .catch((err) =>
+              console.error(
+                '❌ [Attentive] Failed to store Android device token:',
+                err
+              )
+            )
+        }
       )
 
       androidForegroundPushSubscription = attentiveEmitter.addListener(
         'AttentiveForegroundPush',
         (payload: Record<string, string>) => {
-          console.log('📩 [Attentive] Foreground push received (Android):', payload)
+          console.log(
+            '📩 [Attentive] Foreground push received (Android):',
+            payload
+          )
           getPushAuthorizationStatus()
             .then((authStatus: PushAuthorizationStatus) => {
-              handleForegroundPush(payload as PushNotificationUserInfo, authStatus)
-              console.log('✅ [Attentive] handleForegroundPush reported for Android foreground push with payload:', payload)
+              handleForegroundPush(
+                payload as PushNotificationUserInfo,
+                authStatus
+              )
+              console.log(
+                '✅ [Attentive] handleForegroundPush reported for Android foreground push with payload:',
+                payload
+              )
             })
-            .catch((err) => console.error('❌ [Attentive] Failed to get auth status for foreground push:', err))
-        },
+            .catch((err) =>
+              console.error(
+                '❌ [Attentive] Failed to get auth status for foreground push:',
+                err
+              )
+            )
+        }
       )
 
       androidPushOpenedSubscription = attentiveEmitter.addListener(
         'AttentivePushOpened',
         (payload: Record<string, string>) => {
-          console.log('🔔 [Attentive] Push opened from background (Android):', payload)
+          console.log(
+            '🔔 [Attentive] Push opened from background (Android):',
+            payload
+          )
           getPushAuthorizationStatus()
             .then((authStatus: PushAuthorizationStatus) => {
               handlePushOpen(payload as PushNotificationUserInfo, authStatus)
-              console.log('✅ [Attentive] handlePushOpen reported for Android background tap')
+              console.log(
+                '✅ [Attentive] handlePushOpen reported for Android background tap'
+              )
             })
-            .catch((err) => console.error('❌ [Attentive] Failed to get auth status for push-open:', err))
-        },
+            .catch((err) =>
+              console.error(
+                '❌ [Attentive] Failed to get auth status for push-open:',
+                err
+              )
+            )
+        }
       )
     }
 
     // Setup app state listener to track app opens
     // When app comes to foreground, trigger handleRegularOpen to track the app open event
-    console.log('📱 [Attentive] Setting up AppState listener for app open tracking')
+    console.log(
+      '📱 [Attentive] Setting up AppState listener for app open tracking'
+    )
     const appStateSubscription = AppState.addEventListener(
       'change',
       (nextAppState: string) => {
@@ -324,7 +407,10 @@ function App(): React.JSX.Element {
         ) {
           console.log('[Attentive] App became active - tracking app open event')
           trackRegularOpen().catch((error) => {
-            console.error('❌ [Attentive] AppState regular open tracking failed:', error)
+            console.error(
+              '❌ [Attentive] AppState regular open tracking failed:',
+              error
+            )
           })
 
           // Re-register push token only when Android permission just transitioned to authorized.
@@ -345,12 +431,12 @@ function App(): React.JSX.Element {
               .catch((error) => {
                 console.error(
                   '❌ [Attentive] Failed to refresh Android push auth status on foreground:',
-                  error,
+                  error
                 )
               })
           }
         }
-      },
+      }
     )
 
     return () => {
@@ -393,48 +479,57 @@ function App(): React.JSX.Element {
    *   }
    * ```
    */
-  const handleNotificationOpen = useCallback((notification: PushNotification) => {
-    const userInfo = notification.getData()
-    console.log('[Attentive] Notification opened:', userInfo)
+  const handleNotificationOpen = useCallback(
+    (notification: PushNotification) => {
+      const userInfo = notification.getData()
+      console.log('[Attentive] Notification opened:', userInfo)
 
-    // Get current app state (equivalent to UIApplication.shared.applicationState)
-    const appState = AppState.currentState
-    console.log('[Attentive] Current app state:', appState)
+      // Get current app state (equivalent to UIApplication.shared.applicationState)
+      const appState = AppState.currentState
+      console.log('[Attentive] Current app state:', appState)
 
-    // Get authorization status (equivalent to getNotificationSettings)
-    PushNotificationIOS.checkPermissions((permissions) => {
-      let authStatus: PushAuthorizationStatus = 'notDetermined'
-      if (permissions.alert || permissions.badge || permissions.sound) {
-        authStatus = 'authorized'
-      }
-      console.log('[Attentive] Authorization status:', authStatus)
+      // Get authorization status (equivalent to getNotificationSettings)
+      PushNotificationIOS.checkPermissions((permissions) => {
+        let authStatus: PushAuthorizationStatus = 'notDetermined'
+        if (permissions.alert || permissions.badge || permissions.sound) {
+          authStatus = 'authorized'
+        }
+        console.log('[Attentive] Authorization status:', authStatus)
 
-      // Determine which SDK method to call based on app state
-      // This matches the native iOS switch statement exactly
-      switch (appState) {
-        case 'active':
-          // App is in foreground - handle as foreground push
-          console.log('[Attentive] App state: active - calling handleForegroundPush')
-          handleForegroundPush(userInfo, authStatus)
-          break
+        // Determine which SDK method to call based on app state
+        // This matches the native iOS switch statement exactly
+        switch (appState) {
+          case 'active':
+            // App is in foreground - handle as foreground push
+            console.log(
+              '[Attentive] App state: active - calling handleForegroundPush'
+            )
+            handleForegroundPush(userInfo, authStatus)
+            break
 
-        case 'background':
-        case 'inactive':
-          // App is in background or inactive - handle as push open
-          console.log('[Attentive] App state: background/inactive - calling handlePushOpen')
-          handlePushOpen(userInfo, authStatus)
-          break
+          case 'background':
+          case 'inactive':
+            // App is in background or inactive - handle as push open
+            console.log(
+              '[Attentive] App state: background/inactive - calling handlePushOpen'
+            )
+            handlePushOpen(userInfo, authStatus)
+            break
 
-        default:
-          // Unknown state - default to push open behavior (matches @unknown default in Swift)
-          console.log('[Attentive] App state: unknown - calling handlePushOpen')
-          handlePushOpen(userInfo, authStatus)
-          break
-      }
-    })
+          default:
+            // Unknown state - default to push open behavior (matches @unknown default in Swift)
+            console.log(
+              '[Attentive] App state: unknown - calling handlePushOpen'
+            )
+            handlePushOpen(userInfo, authStatus)
+            break
+        }
+      })
 
-    notification.finish(PushNotificationIOS.FetchResult.NoData)
-  }, [])
+      notification.finish(PushNotificationIOS.FetchResult.NoData)
+    },
+    []
+  )
 
   /**
    * Setup push notification handlers (mirrors iOS AppDelegate implementation)
@@ -455,50 +550,69 @@ function App(): React.JSX.Element {
 
     // Handle device token registration
     console.log('📝 [Attentive] Adding "register" event listener')
-    PushNotificationIOS.addEventListener('register', async (deviceToken: string) => {
-      console.log('🎫 [Attentive] Device token received from APNs')
-      console.log('   Token (preview):', deviceToken.substring(0, 16) + '...')
-      console.log('   Token (full):', deviceToken)
-      console.log('   Token length:', deviceToken.length)
+    PushNotificationIOS.addEventListener(
+      'register',
+      async (deviceToken: string) => {
+        console.log('🎫 [Attentive] Device token received from APNs')
+        console.log('   Token (preview):', deviceToken.substring(0, 16) + '...')
+        console.log('   Token (full):', deviceToken)
+        console.log('   Token length:', deviceToken.length)
 
-      // Store token for display in Settings screen
-      await AsyncStorage.setItem('deviceToken', deviceToken)
-      await AsyncStorage.setItem('deviceTokenForDisplay', deviceToken)
+        // Store token for display in Settings screen
+        await AsyncStorage.setItem('deviceToken', deviceToken)
+        await AsyncStorage.setItem('deviceTokenForDisplay', deviceToken)
 
-      // Get authorization status and register with SDK (equivalent to getNotificationSettings)
-      PushNotificationIOS.checkPermissions((permissions) => {
-        let authStatus: PushAuthorizationStatus = 'notDetermined'
-        if (permissions.alert || permissions.badge || permissions.sound) {
-          authStatus = 'authorized'
-        }
-
-        console.log('✅ [Attentive] Authorization status:', authStatus)
-        console.log('📤 [Attentive] Registering device token with Attentive SDK (with callback)')
-
-        // Register device token with callback-based method (equivalent to Swift callback-based registration)
-        registerDeviceTokenWithCallback(
-          deviceToken,
-          authStatus,
-          (data?: Object, url?: string, response?: Object, error?: Object) => {
-            console.log('📥 [Attentive] Registration callback invoked')
-
-            if (error) {
-              console.error('❌ [Attentive] Registration callback returned error:', error)
-            } else {
-              console.log('✅ [Attentive] Device token registered successfully')
-              console.log('   Response URL:', url)
-              console.log('   Response:', response)
-              console.log('   Data:', data)
-            }
-
-            // Trigger regular open event (equivalent to DispatchQueue.main.async { handleRegularOpen })
-            console.log('📱 [Attentive] Triggering regular open event from callback')
-            handleRegularOpen(authStatus)
-            console.log('✅ [Attentive] Regular open event triggered successfully')
+        // Get authorization status and register with SDK (equivalent to getNotificationSettings)
+        PushNotificationIOS.checkPermissions((permissions) => {
+          let authStatus: PushAuthorizationStatus = 'notDetermined'
+          if (permissions.alert || permissions.badge || permissions.sound) {
+            authStatus = 'authorized'
           }
-        )
-      })
-    })
+
+          console.log('✅ [Attentive] Authorization status:', authStatus)
+          console.log(
+            '📤 [Attentive] Registering device token with Attentive SDK (with callback)'
+          )
+
+          // Register device token with callback-based method (equivalent to Swift callback-based registration)
+          registerDeviceTokenWithCallback(
+            deviceToken,
+            authStatus,
+            (
+              data?: Object,
+              url?: string,
+              response?: Object,
+              error?: Object
+            ) => {
+              console.log('📥 [Attentive] Registration callback invoked')
+
+              if (error) {
+                console.error(
+                  '❌ [Attentive] Registration callback returned error:',
+                  error
+                )
+              } else {
+                console.log(
+                  '✅ [Attentive] Device token registered successfully'
+                )
+                console.log('   Response URL:', url)
+                console.log('   Response:', response)
+                console.log('   Data:', data)
+              }
+
+              // Trigger regular open event (equivalent to DispatchQueue.main.async { handleRegularOpen })
+              console.log(
+                '📱 [Attentive] Triggering regular open event from callback'
+              )
+              handleRegularOpen(authStatus)
+              console.log(
+                '✅ [Attentive] Regular open event triggered successfully'
+              )
+            }
+          )
+        })
+      }
+    )
 
     // Handle registration errors
     console.log('📝 [Attentive] Adding "registrationError" event listener')
@@ -508,33 +622,47 @@ function App(): React.JSX.Element {
 
     // Handle push notifications received while app is in foreground
     console.log('📝 [Attentive] Adding "notification" event listener')
-    PushNotificationIOS.addEventListener('notification', (notification: PushNotification) => {
-      const userInfo = notification.getData()
-      console.log('[Attentive] Push notification received in foreground:', userInfo)
+    PushNotificationIOS.addEventListener(
+      'notification',
+      (notification: PushNotification) => {
+        const userInfo = notification.getData()
+        console.log(
+          '[Attentive] Push notification received in foreground:',
+          userInfo
+        )
 
-      // Get authorization status and call handleForegroundPush
-      // This provides better tracking than the legacy handleForegroundNotification
-      PushNotificationIOS.checkPermissions((permissions) => {
-        let authStatus: PushAuthorizationStatus = 'notDetermined'
-        if (permissions.alert || permissions.badge || permissions.sound) {
-          authStatus = 'authorized'
-        }
+        // Get authorization status and call handleForegroundPush
+        // This provides better tracking than the legacy handleForegroundNotification
+        PushNotificationIOS.checkPermissions((permissions) => {
+          let authStatus: PushAuthorizationStatus = 'notDetermined'
+          if (permissions.alert || permissions.badge || permissions.sound) {
+            authStatus = 'authorized'
+          }
 
-        // Use handleForegroundPush for better tracking (matches native iOS pattern)
-        console.log('[Attentive] Calling handleForegroundPush for foreground notification')
-        handleForegroundPush(userInfo, authStatus)
-      })
+          // Use handleForegroundPush for better tracking (matches native iOS pattern)
+          console.log(
+            '[Attentive] Calling handleForegroundPush for foreground notification'
+          )
+          handleForegroundPush(userInfo, authStatus)
+        })
 
-      // Complete the notification
-      notification.finish(PushNotificationIOS.FetchResult.NoData)
-    })
+        // Complete the notification
+        notification.finish(PushNotificationIOS.FetchResult.NoData)
+      }
+    )
 
     // Handle local notifications and notification taps
     console.log('📝 [Attentive] Adding "localNotification" event listener')
-    PushNotificationIOS.addEventListener('localNotification', (notification: PushNotification) => {
-      console.log('🔔 [Attentive] Local notification received:', notification.getMessage())
-      handleNotificationOpen(notification)
-    })
+    PushNotificationIOS.addEventListener(
+      'localNotification',
+      (notification: PushNotification) => {
+        console.log(
+          '🔔 [Attentive] Local notification received:',
+          notification.getMessage()
+        )
+        handleNotificationOpen(notification)
+      }
+    )
 
     // NOTE: Permission request is now handled in the main useEffect with a delay
     // to ensure handleRegularOpen completes before the permission dialog appears
@@ -596,9 +724,10 @@ function App(): React.JSX.Element {
 
   // For Android, transparent string might not work - use rgba format
   // With translucent=true, the background will still show through
-  const statusBarColor = Platform.OS === 'android' && statusBarBackgroundColor === 'transparent'
-    ? 'rgba(0,0,0,0)' // Fully transparent rgba for Android compatibility
-    : statusBarBackgroundColor
+  const statusBarColor =
+    Platform.OS === 'android' && statusBarBackgroundColor === 'transparent'
+      ? 'rgba(0,0,0,0)' // Fully transparent rgba for Android compatibility
+      : statusBarBackgroundColor
 
   return (
     <SafeAreaProvider>
@@ -613,87 +742,87 @@ function App(): React.JSX.Element {
           onReady={handleNavigationStateChange}
           onStateChange={handleNavigationStateChange}
         >
-        <Stack.Navigator
-          initialRouteName="Login"
-          screenOptions={{
-            headerShown: true,
-            headerStyle: {
-              backgroundColor: Colors.peach,
-            },
-            headerTintColor: '#000',
-            headerTitleStyle: {
-              fontWeight: 'bold',
-            },
-            headerBackVisible: false,
-          }}
-        >
-          {/* Login Flow */}
-          <Stack.Screen
-            name="Login"
-            component={LoginScreen}
-            options={{
-              headerShown: false,
+          <Stack.Navigator
+            initialRouteName="Login"
+            screenOptions={{
+              headerShown: true,
+              headerStyle: {
+                backgroundColor: Colors.peach,
+              },
+              headerTintColor: '#000',
+              headerTitleStyle: {
+                fontWeight: 'bold',
+              },
+              headerBackVisible: false,
             }}
-          />
+          >
+            {/* Login Flow */}
+            <Stack.Screen
+              name="Login"
+              component={LoginScreen}
+              options={{
+                headerShown: false,
+              }}
+            />
 
-          <Stack.Screen
-            name="CreateAccount"
-            component={CreateAccountScreen}
-            options={{
-              title: 'Create Account',
-              headerBackTitle: 'Back',
-            }}
-          />
+            <Stack.Screen
+              name="CreateAccount"
+              component={CreateAccountScreen}
+              options={{
+                title: 'Create Account',
+                headerBackTitle: 'Back',
+              }}
+            />
 
-          {/* Main App Flow */}
-          <Stack.Screen
-            name="ProductList"
-            component={ProductListScreen}
-            options={{
-              header: renderCustomHeader,
-            }}
-          />
+            {/* Main App Flow */}
+            <Stack.Screen
+              name="ProductList"
+              component={ProductListScreen}
+              options={{
+                header: renderCustomHeader,
+              }}
+            />
 
-          <Stack.Screen
-            name="ProductDetail"
-            component={ProductDetailScreen}
-            options={{
-              header: renderCustomHeader,
-            }}
-          />
+            <Stack.Screen
+              name="ProductDetail"
+              component={ProductDetailScreen}
+              options={{
+                header: renderCustomHeader,
+              }}
+            />
 
-          <Stack.Screen
-            name="Cart"
-            component={CartScreen}
-            options={{
-              header: renderCustomHeader,
-            }}
-          />
+            <Stack.Screen
+              name="Cart"
+              component={CartScreen}
+              options={{
+                header: renderCustomHeader,
+              }}
+            />
 
-          <Stack.Screen
-            name="Checkout"
-            component={CheckoutScreen}
-            options={{
-              header: renderCustomHeader,
-            }}
-          />
+            <Stack.Screen
+              name="Checkout"
+              component={CheckoutScreen}
+              options={{
+                header: renderCustomHeader,
+              }}
+            />
 
-          <Stack.Screen
-            name="OrderConfirmation"
-            component={OrderConfirmationScreen}
-            options={{
-              headerShown: false,
-            }}
-          />
+            <Stack.Screen
+              name="OrderConfirmation"
+              component={OrderConfirmationScreen}
+              options={{
+                headerShown: false,
+              }}
+            />
 
-          <Stack.Screen
-            name="Settings"
-            component={SettingsScreen}
-            options={{
-              header: renderCustomHeader,
-            }}
-          />
-        </Stack.Navigator>
+            <Stack.Screen
+              name="Settings"
+              component={SettingsScreen}
+              options={{
+                header: renderCustomHeader,
+              }}
+            />
+          </Stack.Navigator>
         </NavigationContainer>
       </CartProvider>
     </SafeAreaProvider>

--- a/Bonni/__tests__/useMarketingSubscriptions.test.ts
+++ b/Bonni/__tests__/useMarketingSubscriptions.test.ts
@@ -56,9 +56,7 @@ describe('useMarketingSubscriptions', () => {
   describe('handleSetEmail', () => {
     it('should commit a valid email and call identify', () => {
       const onSuccess = jest.fn()
-      const { result } = renderHook(() =>
-        useMarketingSubscriptions(onSuccess)
-      )
+      const { result } = renderHook(() => useMarketingSubscriptions(onSuccess))
 
       act(() => result.current.setEmailInput('user@example.com'))
       act(() => result.current.handleSetEmail())
@@ -87,9 +85,7 @@ describe('useMarketingSubscriptions', () => {
   describe('handleSetPhone', () => {
     it('should commit a valid phone and call identify', () => {
       const onSuccess = jest.fn()
-      const { result } = renderHook(() =>
-        useMarketingSubscriptions(onSuccess)
-      )
+      const { result } = renderHook(() => useMarketingSubscriptions(onSuccess))
 
       act(() => result.current.setPhoneInput('+15551234567'))
       act(() => result.current.handleSetPhone())
@@ -118,9 +114,7 @@ describe('useMarketingSubscriptions', () => {
   describe('handleOptInEmail', () => {
     it('should call optInMarketingSubscription and invoke onSuccess', async () => {
       const onSuccess = jest.fn()
-      const { result } = renderHook(() =>
-        useMarketingSubscriptions(onSuccess)
-      )
+      const { result } = renderHook(() => useMarketingSubscriptions(onSuccess))
 
       act(() => result.current.setEmailInput('user@example.com'))
 
@@ -149,9 +143,7 @@ describe('useMarketingSubscriptions', () => {
   describe('handleOptOutEmail', () => {
     it('should call optOutMarketingSubscription and invoke onSuccess', async () => {
       const onSuccess = jest.fn()
-      const { result } = renderHook(() =>
-        useMarketingSubscriptions(onSuccess)
-      )
+      const { result } = renderHook(() => useMarketingSubscriptions(onSuccess))
 
       act(() => result.current.setEmailInput('user@example.com'))
 
@@ -167,9 +159,7 @@ describe('useMarketingSubscriptions', () => {
   describe('handleOptInPhone', () => {
     it('should call optInMarketingSubscription and invoke onSuccess', async () => {
       const onSuccess = jest.fn()
-      const { result } = renderHook(() =>
-        useMarketingSubscriptions(onSuccess)
-      )
+      const { result } = renderHook(() => useMarketingSubscriptions(onSuccess))
 
       act(() => result.current.setPhoneInput('+15551234567'))
 
@@ -198,9 +188,7 @@ describe('useMarketingSubscriptions', () => {
   describe('handleOptOutPhone', () => {
     it('should call optOutMarketingSubscription and invoke onSuccess', async () => {
       const onSuccess = jest.fn()
-      const { result } = renderHook(() =>
-        useMarketingSubscriptions(onSuccess)
-      )
+      const { result } = renderHook(() => useMarketingSubscriptions(onSuccess))
 
       act(() => result.current.setPhoneInput('+15551234567'))
 

--- a/Bonni/__tests__/useTextPrompt.test.tsx
+++ b/Bonni/__tests__/useTextPrompt.test.tsx
@@ -56,7 +56,7 @@ describe('useTextPrompt – iOS', () => {
       'Test message',
       expect.any(Array),
       'plain-text',
-      'default',
+      'default'
     )
   })
 
@@ -151,7 +151,11 @@ describe('useTextPrompt – Android', () => {
     const { result } = renderHook(() => useTextPrompt())
 
     act(() => {
-      result.current.showPrompt({ title: 'Domain', defaultValue: 'games', onConfirm: jest.fn() })
+      result.current.showPrompt({
+        title: 'Domain',
+        defaultValue: 'games',
+        onConfirm: jest.fn(),
+      })
     })
 
     const modal = result.current.PromptModal as React.ReactElement

--- a/Bonni/index.js
+++ b/Bonni/index.js
@@ -2,8 +2,8 @@
  * @format
  */
 
-import {AppRegistry} from 'react-native'
+import { AppRegistry } from 'react-native'
 import App from './App'
-import {name as appName} from './app.json'
+import { name as appName } from './app.json'
 
 AppRegistry.registerComponent(appName, () => App)

--- a/Bonni/jest.setup.js
+++ b/Bonni/jest.setup.js
@@ -23,7 +23,7 @@ const nativeModuleStub = () =>
         }
         return jest.fn(() => Promise.resolve())
       },
-    },
+    }
   )
 
 // The SDK source resolves the *repo-root* copy of react-native (the host app
@@ -51,9 +51,8 @@ jest.mock('../src/NativeAttentiveReactNativeSdk', () => ({
 NativeModules.AttentiveReactNativeSdk = nativeModuleStub()
 
 // AsyncStorage ships an official jest mock.
-jest.mock(
-  '@react-native-async-storage/async-storage',
-  () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
 )
 
 // @react-native-community/push-notification-ios has no bundled jest mock; stub the

--- a/Bonni/package-lock.json
+++ b/Bonni/package-lock.json
@@ -37,6 +37,8 @@
         "@types/react": "^18.2.6",
         "@types/react-test-renderer": "^18.0.0",
         "eslint": "^8.19.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.0.0",
         "jest": "^29.6.3",
         "prettier": "2.8.8",
         "react-native-svg-transformer": "^1.5.2",
@@ -49,7 +51,7 @@
     },
     "..": {
       "name": "@attentive-mobile/attentive-react-native-sdk",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",
@@ -6684,6 +6686,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.5.tgz",
+      "integrity": "sha512-9Ni+xgemM2IWLq6aXEpP2+V/V30GeA/46Ar629vcMqVPodFFWC9skHu/D1phvuqtS8bJCFnNf01/qcmqYEwNfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -7074,6 +7098,13 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -11369,6 +11400,19 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/Bonni/package.json
+++ b/Bonni/package.json
@@ -44,6 +44,8 @@
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
     "eslint": "^8.19.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-native-svg-transformer": "^1.5.2",

--- a/Bonni/src/components/CustomHeader.tsx
+++ b/Bonni/src/components/CustomHeader.tsx
@@ -5,12 +5,7 @@
  */
 
 import React from 'react'
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-} from 'react-native'
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
 import { useNavigation, useRoute } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -23,11 +18,11 @@ import BurgerIcon from '../assets/images/ui/icons/burger-icon.svg'
 import CartIcon from '../assets/images/ui/icons/cart-icon.svg'
 import BonniLogo from '../assets/images/ui/icons/bonni-logo.svg'
 
-type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>
 
 interface CustomHeaderProps {
-  showLogo?: boolean;
-  showCartIcon?: boolean;
+  showLogo?: boolean
+  showCartIcon?: boolean
 }
 
 /**
@@ -50,10 +45,7 @@ const CustomHeader: React.FC<CustomHeaderProps> = ({
   const canGoBack = navigation.canGoBack()
   const shouldShowBackButton = !isProductListScreen && canGoBack
 
-  const cartItemCount = cartItems.reduce(
-    (sum, item) => sum + item.quantity,
-    0
-  )
+  const cartItemCount = cartItems.reduce((sum, item) => sum + item.quantity, 0)
 
   const handleBackPress = () => {
     if (canGoBack) {
@@ -92,11 +84,7 @@ const CustomHeader: React.FC<CustomHeaderProps> = ({
         </View>
 
         {/* Center - Logo */}
-        <View style={styles.centerContent}>
-          {showLogo && (
-            <BonniLogo />
-          )}
-        </View>
+        <View style={styles.centerContent}>{showLogo && <BonniLogo />}</View>
 
         {/* Right Button - Cart */}
         <View style={styles.rightButton}>

--- a/Bonni/src/components/TextPromptModal.tsx
+++ b/Bonni/src/components/TextPromptModal.tsx
@@ -100,7 +100,11 @@ export const TextPromptModal: React.FC<TextPromptModalProps> = ({
             {/* Actions */}
             <View style={styles.actions}>
               <Pressable
-                style={({ pressed }) => [styles.button, styles.cancelButton, pressed && styles.buttonPressed]}
+                style={({ pressed }) => [
+                  styles.button,
+                  styles.cancelButton,
+                  pressed && styles.buttonPressed,
+                ]}
                 onPress={onDismiss}
                 accessibilityRole="button"
                 accessibilityLabel={cancelText}
@@ -111,7 +115,11 @@ export const TextPromptModal: React.FC<TextPromptModalProps> = ({
               <View style={styles.buttonDivider} />
 
               <Pressable
-                style={({ pressed }) => [styles.button, styles.confirmButton, pressed && styles.buttonPressed]}
+                style={({ pressed }) => [
+                  styles.button,
+                  styles.confirmButton,
+                  pressed && styles.buttonPressed,
+                ]}
                 onPress={handleConfirm}
                 accessibilityRole="button"
                 accessibilityLabel={confirmText}

--- a/Bonni/src/constants/buttonStyles.ts
+++ b/Bonni/src/constants/buttonStyles.ts
@@ -185,4 +185,3 @@ export const ButtonStyles = StyleSheet.create({
   ghostText: ghostButtonText,
   ghostTextPressed: ghostButtonTextPressed,
 })
-

--- a/Bonni/src/constants/theme.ts
+++ b/Bonni/src/constants/theme.ts
@@ -28,12 +28,12 @@ export const Typography = {
   // Font sizes
   sizes: {
     xxxl: 40, // Welcome text
-    xxl: 30,  // Headers
-    xl: 24,   // Product titles
+    xxl: 30, // Headers
+    xl: 24, // Product titles
     large: 20, // Prices
     medium: 16, // Body text
-    small: 14,  // Secondary text
-    xs: 12,     // Small labels
+    small: 14, // Secondary text
+    xs: 12, // Small labels
   },
 
   // Font weights

--- a/Bonni/src/hooks/index.ts
+++ b/Bonni/src/hooks/index.ts
@@ -11,4 +11,3 @@ export { useAttentiveActions } from './useAttentiveActions'
 export { useDisplayAlerts } from './useDisplayAlerts'
 export { useAttentiveDomain } from './useAttentiveDomain'
 export { useTextPrompt } from './useTextPrompt'
-

--- a/Bonni/src/hooks/useAttentiveActions.ts
+++ b/Bonni/src/hooks/useAttentiveActions.ts
@@ -44,4 +44,3 @@ export function useAttentiveActions() {
     recordCustomAttentiveEvent,
   }
 }
-

--- a/Bonni/src/hooks/useAttentiveDomain.ts
+++ b/Bonni/src/hooks/useAttentiveDomain.ts
@@ -71,7 +71,9 @@ export function useAttentiveDomain(): AttentiveDomainHook {
    */
   const saveDomain = useCallback(async (newDomain: string) => {
     const trimmed = newDomain.trim()
-    if (!trimmed) { return }
+    if (!trimmed) {
+      return
+    }
     try {
       await AsyncStorage.setItem(DOMAIN_STORAGE_KEY, trimmed)
       updateDomain(trimmed)

--- a/Bonni/src/hooks/useAttentiveEvents.ts
+++ b/Bonni/src/hooks/useAttentiveEvents.ts
@@ -83,7 +83,12 @@ export function useAddToCart() {
  */
 export function usePurchase() {
   const recordPurchase = useCallback(
-    (cartItems: CartItem[], orderId: string, cartId?: string, cartCoupon?: string) => {
+    (
+      cartItems: CartItem[],
+      orderId: string,
+      cartId?: string,
+      cartCoupon?: string
+    ) => {
       const items: Item[] = cartItems.map((item) =>
         productToItem(item.product, item.quantity)
       )
@@ -100,4 +105,3 @@ export function usePurchase() {
 
   return { recordPurchase }
 }
-

--- a/Bonni/src/hooks/useAttentiveUser.ts
+++ b/Bonni/src/hooks/useAttentiveUser.ts
@@ -4,7 +4,11 @@
  */
 
 import { useCallback } from 'react'
-import { identify, clearUser, type UserIdentifiers } from '@attentive-mobile/attentive-react-native-sdk'
+import {
+  identify,
+  clearUser,
+  type UserIdentifiers,
+} from '@attentive-mobile/attentive-react-native-sdk'
 
 /**
  * Hook for user identification operations

--- a/Bonni/src/hooks/useDisplayAlerts.ts
+++ b/Bonni/src/hooks/useDisplayAlerts.ts
@@ -32,5 +32,3 @@ export function useDisplayAlerts() {
 
   return displayAlerts
 }
-
-

--- a/Bonni/src/hooks/useMarketingSubscriptions.ts
+++ b/Bonni/src/hooks/useMarketingSubscriptions.ts
@@ -63,7 +63,10 @@ export function useMarketingSubscriptions(
 
   const isAnyLoading = useMemo(
     () =>
-      isOptingInEmail || isOptingOutEmail || isOptingInPhone || isOptingOutPhone,
+      isOptingInEmail ||
+      isOptingOutEmail ||
+      isOptingInPhone ||
+      isOptingOutPhone,
     [isOptingInEmail, isOptingOutEmail, isOptingInPhone, isOptingOutPhone]
   )
 

--- a/Bonni/src/hooks/useTextPrompt.tsx
+++ b/Bonni/src/hooks/useTextPrompt.tsx
@@ -102,11 +102,14 @@ export function useTextPrompt(): TextPromptHook {
     setState((prev) => ({ ...prev, visible: false }))
   }, [])
 
-  const handleConfirm = useCallback((value: string) => {
-    const trimmed = value.trim()
-    dismiss()
-    if (trimmed) state.onConfirm(trimmed)
-  }, [dismiss, state])
+  const handleConfirm = useCallback(
+    (value: string) => {
+      const trimmed = value.trim()
+      dismiss()
+      if (trimmed) state.onConfirm(trimmed)
+    },
+    [dismiss, state]
+  )
 
   const handleCancel = useCallback(() => {
     dismiss()
@@ -141,7 +144,7 @@ export function useTextPrompt(): TextPromptHook {
           },
         ],
         'plain-text',
-        defaultValue,
+        defaultValue
       )
       return
     }
@@ -161,19 +164,20 @@ export function useTextPrompt(): TextPromptHook {
   }, [])
 
   // PromptModal is only meaningful on Android; return null on iOS to keep renders clean
-  const PromptModal: React.ReactElement | null = Platform.OS === 'ios' ? null : (
-    <TextPromptModal
-      visible={state.visible}
-      title={state.title}
-      message={state.message}
-      defaultValue={state.defaultValue}
-      placeholder={state.placeholder}
-      confirmText={state.confirmText}
-      cancelText={state.cancelText}
-      onConfirm={handleConfirm}
-      onDismiss={handleCancel}
-    />
-  )
+  const PromptModal: React.ReactElement | null =
+    Platform.OS === 'ios' ? null : (
+      <TextPromptModal
+        visible={state.visible}
+        title={state.title}
+        message={state.message}
+        defaultValue={state.defaultValue}
+        placeholder={state.placeholder}
+        confirmText={state.confirmText}
+        cancelText={state.cancelText}
+        onConfirm={handleConfirm}
+        onDismiss={handleCancel}
+      />
+    )
 
   return { showPrompt, PromptModal }
 }

--- a/Bonni/src/models/CartContext.tsx
+++ b/Bonni/src/models/CartContext.tsx
@@ -7,14 +7,14 @@ import React, { createContext, useContext, useState, ReactNode } from 'react'
 import { Product, CartItem } from './Product'
 
 interface CartContextType {
-  cartItems: CartItem[];
-  addToCart: (product: Product) => void;
-  removeFromCart: (productId: string) => void;
-  updateQuantity: (productId: string, quantity: number) => void;
-  clearCart: () => void;
-  getSubtotal: () => number;
-  getTax: () => number;
-  getTotal: () => number;
+  cartItems: CartItem[]
+  addToCart: (product: Product) => void
+  removeFromCart: (productId: string) => void
+  updateQuantity: (productId: string, quantity: number) => void
+  clearCart: () => void
+  getSubtotal: () => number
+  getTax: () => number
+  getTotal: () => number
 }
 
 const CartContext = createContext<CartContextType | undefined>(undefined)
@@ -28,7 +28,7 @@ export const useCart = () => {
 }
 
 interface CartProviderProps {
-  children: ReactNode;
+  children: ReactNode
 }
 
 export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {

--- a/Bonni/src/models/Product.ts
+++ b/Bonni/src/models/Product.ts
@@ -3,16 +3,16 @@
  */
 
 export interface Product {
-  id: string;
-  name: string;
-  price: number;
-  image: any; // React Native image require() type
-  category?: string;
+  id: string
+  name: string
+  price: number
+  image: any // React Native image require() type
+  category?: string
 }
 
 export interface CartItem {
-  product: Product;
-  quantity: number;
+  product: Product
+  quantity: number
 }
 
 // Product catalog - matching the iOS app products

--- a/Bonni/src/screens/CartScreen.tsx
+++ b/Bonni/src/screens/CartScreen.tsx
@@ -17,11 +17,13 @@ import { CartScreenProps } from '../types/navigation'
 import { useCart } from '../models/CartContext'
 import { CartItem } from '../models/Product'
 import { Colors, Typography, Spacing, BorderRadius } from '../constants/theme'
-import { getPrimaryButtonStyle, getPrimaryButtonTextStyle } from '../constants/buttonStyles'
+import {
+  getPrimaryButtonStyle,
+  getPrimaryButtonTextStyle,
+} from '../constants/buttonStyles'
 
 const CartScreen: React.FC<CartScreenProps> = ({ navigation }) => {
-  const { cartItems, updateQuantity, getSubtotal, getTax, getTotal } =
-    useCart()
+  const { cartItems, updateQuantity, getSubtotal, getTax, getTotal } = useCart()
 
   const handleCheckout = () => {
     if (cartItems.length === 0) {
@@ -36,25 +38,19 @@ const CartScreen: React.FC<CartScreenProps> = ({ navigation }) => {
       <View style={styles.itemDetails}>
         <Text style={styles.itemName}>{item.product.name}</Text>
         <Text style={styles.itemCategory}>Skincare</Text>
-        <Text style={styles.itemPrice}>
-          ${item.product.price.toFixed(2)}
-        </Text>
+        <Text style={styles.itemPrice}>${item.product.price.toFixed(2)}</Text>
       </View>
       <View style={styles.quantityControls}>
         <TouchableOpacity
           style={styles.quantityButton}
-          onPress={() =>
-            updateQuantity(item.product.id, item.quantity - 1)
-          }
+          onPress={() => updateQuantity(item.product.id, item.quantity - 1)}
         >
           <Text style={styles.quantityButtonText}>-</Text>
         </TouchableOpacity>
         <Text style={styles.quantity}>{item.quantity}</Text>
         <TouchableOpacity
           style={styles.quantityButton}
-          onPress={() =>
-            updateQuantity(item.product.id, item.quantity + 1)
-          }
+          onPress={() => updateQuantity(item.product.id, item.quantity + 1)}
         >
           <Text style={styles.quantityButtonText}>+</Text>
         </TouchableOpacity>
@@ -98,11 +94,16 @@ const CartScreen: React.FC<CartScreenProps> = ({ navigation }) => {
       <View style={styles.emptyContainer}>
         <Text style={styles.emptyText}>Your cart is empty</Text>
         <Pressable
-          style={({ pressed }) => [getPrimaryButtonStyle(pressed), { paddingHorizontal: Spacing.xxxl }]}
+          style={({ pressed }) => [
+            getPrimaryButtonStyle(pressed),
+            { paddingHorizontal: Spacing.xxxl },
+          ]}
           onPress={() => navigation.navigate('ProductList')}
         >
           {({ pressed }) => (
-            <Text style={getPrimaryButtonTextStyle(pressed)}>Start Shopping</Text>
+            <Text style={getPrimaryButtonTextStyle(pressed)}>
+              Start Shopping
+            </Text>
           )}
         </Pressable>
       </View>

--- a/Bonni/src/screens/CheckoutScreen.tsx
+++ b/Bonni/src/screens/CheckoutScreen.tsx
@@ -16,8 +16,17 @@ import {
 } from 'react-native'
 import { CheckoutScreenProps } from '../types/navigation'
 import { useCart } from '../models/CartContext'
-import { Colors, Typography, Spacing, Layout, BorderRadius } from '../constants/theme'
-import { getPrimaryButtonStyle, getPrimaryButtonTextStyle } from '../constants/buttonStyles'
+import {
+  Colors,
+  Typography,
+  Spacing,
+  Layout,
+  BorderRadius,
+} from '../constants/theme'
+import {
+  getPrimaryButtonStyle,
+  getPrimaryButtonTextStyle,
+} from '../constants/buttonStyles'
 import { usePurchase } from '../hooks/useAttentiveEvents'
 
 const PLACEHOLDER_TEXT_COLOR = '#666666'
@@ -209,7 +218,10 @@ const CheckoutScreen: React.FC<CheckoutScreenProps> = ({ navigation }) => {
         </View>
 
         <Pressable
-          style={({ pressed }) => [getPrimaryButtonStyle(pressed), { marginHorizontal: Spacing.base, marginTop: Spacing.xl }]}
+          style={({ pressed }) => [
+            getPrimaryButtonStyle(pressed),
+            { marginHorizontal: Spacing.base, marginTop: Spacing.xl },
+          ]}
           onPress={handlePlaceOrder}
         >
           {({ pressed }) => (

--- a/Bonni/src/screens/CreateAccountScreen.tsx
+++ b/Bonni/src/screens/CreateAccountScreen.tsx
@@ -15,11 +15,22 @@ import {
   Platform,
 } from 'react-native'
 import { CreateAccountScreenProps } from '../types/navigation'
-import { Colors, Typography, Spacing, Layout, BorderRadius } from '../constants/theme'
-import { getPrimaryButtonStyle, getPrimaryButtonTextStyle } from '../constants/buttonStyles'
+import {
+  Colors,
+  Typography,
+  Spacing,
+  Layout,
+  BorderRadius,
+} from '../constants/theme'
+import {
+  getPrimaryButtonStyle,
+  getPrimaryButtonTextStyle,
+} from '../constants/buttonStyles'
 import { useAttentiveUser } from '../hooks/useAttentiveUser'
 
-const CreateAccountScreen: React.FC<CreateAccountScreenProps> = ({ navigation }) => {
+const CreateAccountScreen: React.FC<CreateAccountScreenProps> = ({
+  navigation,
+}) => {
   const [fullName, setFullName] = useState('')
   const [email, setEmail] = useState('')
   const [phone, setPhone] = useState('')
@@ -88,11 +99,16 @@ const CreateAccountScreen: React.FC<CreateAccountScreenProps> = ({ navigation })
             </View>
 
             <Pressable
-              style={({ pressed }) => [getPrimaryButtonStyle(pressed), { marginTop: Spacing.xl }]}
+              style={({ pressed }) => [
+                getPrimaryButtonStyle(pressed),
+                { marginTop: Spacing.xl },
+              ]}
               onPress={handleCreateAccount}
             >
               {({ pressed }) => (
-                <Text style={getPrimaryButtonTextStyle(pressed)}>CREATE ACCOUNT</Text>
+                <Text style={getPrimaryButtonTextStyle(pressed)}>
+                  CREATE ACCOUNT
+                </Text>
               )}
             </Pressable>
           </View>

--- a/Bonni/src/screens/LoginScreen.tsx
+++ b/Bonni/src/screens/LoginScreen.tsx
@@ -15,7 +15,14 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { LoginScreenProps } from '../types/navigation'
 import { Colors, Typography, Spacing } from '../constants/theme'
-import { ButtonStyles, getPrimaryButtonStyle, getPrimaryButtonTextStyle, getSecondaryButtonStyle, getSecondaryButtonTextStyle, getGhostButtonTextStyle } from '../constants/buttonStyles'
+import {
+  ButtonStyles,
+  getPrimaryButtonStyle,
+  getPrimaryButtonTextStyle,
+  getSecondaryButtonStyle,
+  getSecondaryButtonTextStyle,
+  getGhostButtonTextStyle,
+} from '../constants/buttonStyles'
 
 const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
   const handleSignIn = () => {
@@ -38,42 +45,39 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
     >
       <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']}>
         <View style={styles.content}>
-        <Text style={styles.greetingText}>
-          HEY BESTIE!
-        </Text>
-        <Text style={styles.welcomeText}>
-          Welcome to{'\n'}Bonni Beauty!
-        </Text>
+          <Text style={styles.greetingText}>HEY BESTIE!</Text>
+          <Text style={styles.welcomeText}>Welcome to{'\n'}Bonni Beauty!</Text>
 
-        <View style={styles.buttonContainer}>
-          <Pressable
-            style={({ pressed }) => getPrimaryButtonStyle(pressed)}
-            onPress={handleSignIn}
-          >
-            {({ pressed }) => (
-              <Text style={getPrimaryButtonTextStyle(pressed)}>SIGN IN</Text>
-            )}
-          </Pressable>
+          <View style={styles.buttonContainer}>
+            <Pressable
+              style={({ pressed }) => getPrimaryButtonStyle(pressed)}
+              onPress={handleSignIn}
+            >
+              {({ pressed }) => (
+                <Text style={getPrimaryButtonTextStyle(pressed)}>SIGN IN</Text>
+              )}
+            </Pressable>
 
-          <Pressable
-            style={({ pressed }) => getSecondaryButtonStyle(pressed)}
-            onPress={handleContinueAsGuest}
-          >
-            {({ pressed }) => (
-              <Text style={getSecondaryButtonTextStyle(pressed)}>CONTINUE AS GUEST</Text>
-            )}
-          </Pressable>
+            <Pressable
+              style={({ pressed }) => getSecondaryButtonStyle(pressed)}
+              onPress={handleContinueAsGuest}
+            >
+              {({ pressed }) => (
+                <Text style={getSecondaryButtonTextStyle(pressed)}>
+                  CONTINUE AS GUEST
+                </Text>
+              )}
+            </Pressable>
 
-          <Pressable
-            style={ButtonStyles.ghost}
-            onPress={handleCreateAccount}
-          >
-            {({ pressed }) => (
-              <Text style={getGhostButtonTextStyle(pressed)}>Create Account</Text>
-            )}
-          </Pressable>
+            <Pressable style={ButtonStyles.ghost} onPress={handleCreateAccount}>
+              {({ pressed }) => (
+                <Text style={getGhostButtonTextStyle(pressed)}>
+                  Create Account
+                </Text>
+              )}
+            </Pressable>
+          </View>
         </View>
-      </View>
       </SafeAreaView>
     </ImageBackground>
   )

--- a/Bonni/src/screens/OrderConfirmationScreen.tsx
+++ b/Bonni/src/screens/OrderConfirmationScreen.tsx
@@ -4,16 +4,14 @@
  */
 
 import React from 'react'
-import {
-  View,
-  Text,
-  StyleSheet,
-  Pressable,
-} from 'react-native'
+import { View, Text, StyleSheet, Pressable } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { OrderConfirmationScreenProps } from '../types/navigation'
 import { Colors, Typography, Spacing, BorderRadius } from '../constants/theme'
-import { getPrimaryButtonStyle, getPrimaryButtonTextStyle } from '../constants/buttonStyles'
+import {
+  getPrimaryButtonStyle,
+  getPrimaryButtonTextStyle,
+} from '../constants/buttonStyles'
 
 const OrderConfirmationScreen: React.FC<OrderConfirmationScreenProps> = ({
   route,
@@ -33,31 +31,38 @@ const OrderConfirmationScreen: React.FC<OrderConfirmationScreenProps> = ({
     <View style={styles.container}>
       <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']}>
         <View style={styles.content}>
-        <View style={styles.iconContainer}>
-          <Text style={styles.checkmark}>✓</Text>
+          <View style={styles.iconContainer}>
+            <Text style={styles.checkmark}>✓</Text>
+          </View>
+
+          <Text style={styles.title}>Thank you for shopping with us!</Text>
+
+          <Text style={styles.message}>
+            Your order has been placed successfully.
+          </Text>
+
+          <View style={styles.orderInfo}>
+            <Text style={styles.orderLabel}>Order Number:</Text>
+            <Text style={styles.orderId}>{orderId}</Text>
+          </View>
+
+          <Text style={styles.confirmationText}>
+            You will receive a confirmation email shortly with your order
+            details.
+          </Text>
+
+          <Pressable
+            style={({ pressed }) => [
+              getPrimaryButtonStyle(pressed),
+              { width: '100%' },
+            ]}
+            onPress={handleDone}
+          >
+            {({ pressed }) => (
+              <Text style={getPrimaryButtonTextStyle(pressed)}>DONE</Text>
+            )}
+          </Pressable>
         </View>
-
-        <Text style={styles.title}>Thank you for shopping with us!</Text>
-
-        <Text style={styles.message}>
-          Your order has been placed successfully.
-        </Text>
-
-        <View style={styles.orderInfo}>
-          <Text style={styles.orderLabel}>Order Number:</Text>
-          <Text style={styles.orderId}>{orderId}</Text>
-        </View>
-
-        <Text style={styles.confirmationText}>
-          You will receive a confirmation email shortly with your order details.
-        </Text>
-
-        <Pressable style={({ pressed }) => [getPrimaryButtonStyle(pressed), { width: '100%' }]} onPress={handleDone}>
-          {({ pressed }) => (
-            <Text style={getPrimaryButtonTextStyle(pressed)}>DONE</Text>
-          )}
-        </Pressable>
-      </View>
       </SafeAreaView>
     </View>
   )

--- a/Bonni/src/screens/ProductDetailScreen.tsx
+++ b/Bonni/src/screens/ProductDetailScreen.tsx
@@ -17,7 +17,10 @@ import {
 import { ProductDetailScreenProps } from '../types/navigation'
 import { useCart } from '../models/CartContext'
 import { Colors, Typography, Spacing } from '../constants/theme'
-import { getPrimaryButtonStyle, getPrimaryButtonTextStyle } from '../constants/buttonStyles'
+import {
+  getPrimaryButtonStyle,
+  getPrimaryButtonTextStyle,
+} from '../constants/buttonStyles'
 import { useProductView, useAddToCart } from '../hooks/useAttentiveEvents'
 import { useDisplayAlerts } from '../hooks/useDisplayAlerts'
 
@@ -52,7 +55,13 @@ const ProductDetailScreen: React.FC<ProductDetailScreenProps> = ({
         ]
       )
     }
-  }, [product, handleAddToCartWithTracking, addToCart, navigation, displayAlerts])
+  }, [
+    product,
+    handleAddToCartWithTracking,
+    addToCart,
+    navigation,
+    displayAlerts,
+  ])
 
   return (
     <ScrollView style={styles.container}>
@@ -65,11 +74,14 @@ const ProductDetailScreen: React.FC<ProductDetailScreenProps> = ({
         <Text style={styles.productPrice}>${product.price.toFixed(2)}</Text>
 
         <Text style={styles.description}>
-          Discover the luxurious {product.name} from Bonni Beauty.
-          Crafted with premium ingredients to give you the best skincare experience.
+          Discover the luxurious {product.name} from Bonni Beauty. Crafted with
+          premium ingredients to give you the best skincare experience.
         </Text>
 
-        <Pressable style={({ pressed }) => getPrimaryButtonStyle(pressed)} onPress={handleAddToCart}>
+        <Pressable
+          style={({ pressed }) => getPrimaryButtonStyle(pressed)}
+          onPress={handleAddToCart}
+        >
           {({ pressed }) => (
             <Text style={getPrimaryButtonTextStyle(pressed)}>ADD TO CART</Text>
           )}

--- a/Bonni/src/screens/ProductListScreen.tsx
+++ b/Bonni/src/screens/ProductListScreen.tsx
@@ -22,41 +22,52 @@ import { useDisplayAlerts } from '../hooks/useDisplayAlerts'
 
 import CartIcon from '../assets/images/ui/icons/cart-icon.svg'
 
-const ProductListScreen: React.FC<ProductListScreenProps> = ({ navigation }) => {
+const ProductListScreen: React.FC<ProductListScreenProps> = ({
+  navigation,
+}) => {
   const { addToCart } = useCart()
   const { handleAddToCart: handleAddToCartWithTracking } = useAddToCart()
   const displayAlerts = useDisplayAlerts()
 
-  const handleProductPress = useCallback((product: Product) => {
-    navigation.navigate('ProductDetail', { product })
-  }, [navigation])
+  const handleProductPress = useCallback(
+    (product: Product) => {
+      navigation.navigate('ProductDetail', { product })
+    },
+    [navigation]
+  )
 
-  const handleAddToCart = useCallback((product: Product) => {
-    handleAddToCartWithTracking(product, addToCart)
-    if (displayAlerts) {
-      Alert.alert('Added to Cart', `${product.name} added to cart!`)
-    }
-  }, [handleAddToCartWithTracking, addToCart, displayAlerts])
+  const handleAddToCart = useCallback(
+    (product: Product) => {
+      handleAddToCartWithTracking(product, addToCart)
+      if (displayAlerts) {
+        Alert.alert('Added to Cart', `${product.name} added to cart!`)
+      }
+    },
+    [handleAddToCartWithTracking, addToCart, displayAlerts]
+  )
 
-  const renderProduct = useCallback(({ item }: { item: Product }) => (
-    <View style={styles.productCard}>
-      <TouchableOpacity
-        style={styles.imageContainer}
-        onPress={() => handleProductPress(item)}
-        activeOpacity={0.7}
-      >
-        <Image source={item.image} style={styles.productImage} />
+  const renderProduct = useCallback(
+    ({ item }: { item: Product }) => (
+      <View style={styles.productCard}>
         <TouchableOpacity
-          style={styles.addButton}
-          onPress={() => handleAddToCart(item)}
+          style={styles.imageContainer}
+          onPress={() => handleProductPress(item)}
+          activeOpacity={0.7}
         >
-          <CartIcon width={15} height={15} />
+          <Image source={item.image} style={styles.productImage} />
+          <TouchableOpacity
+            style={styles.addButton}
+            onPress={() => handleAddToCart(item)}
+          >
+            <CartIcon width={15} height={15} />
+          </TouchableOpacity>
         </TouchableOpacity>
-      </TouchableOpacity>
-      <Text style={styles.productName}>{item.name}</Text>
-      <Text style={styles.productPrice}>${item.price.toFixed(2)}</Text>
-    </View>
-  ), [handleProductPress, handleAddToCart])
+        <Text style={styles.productName}>{item.name}</Text>
+        <Text style={styles.productPrice}>${item.price.toFixed(2)}</Text>
+      </View>
+    ),
+    [handleProductPress, handleAddToCart]
+  )
 
   return (
     <View style={styles.container}>

--- a/Bonni/src/screens/SettingsScreen.tsx
+++ b/Bonni/src/screens/SettingsScreen.tsx
@@ -20,8 +20,19 @@ import {
   ActivityIndicator,
 } from 'react-native'
 import { SettingsScreenProps } from '../types/navigation'
-import { Colors, Typography, Spacing, Layout, BorderRadius } from '../constants/theme'
-import { getPrimaryButtonStyle, getPrimaryButtonTextStyle, getSecondaryButtonStyle, getSecondaryButtonTextStyle } from '../constants/buttonStyles'
+import {
+  Colors,
+  Typography,
+  Spacing,
+  Layout,
+  BorderRadius,
+} from '../constants/theme'
+import {
+  getPrimaryButtonStyle,
+  getPrimaryButtonTextStyle,
+  getSecondaryButtonStyle,
+  getSecondaryButtonTextStyle,
+} from '../constants/buttonStyles'
 import { useAttentiveUser } from '../hooks/useAttentiveUser'
 import { useAttentiveActions } from '../hooks/useAttentiveActions'
 import { useAttentiveDomain } from '../hooks/useAttentiveDomain'
@@ -50,10 +61,16 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
   const [responseData, setResponseData] = useState<string>('')
   const [debuggerEnabled, setDebuggerEnabled] = useState<boolean>(true)
   const [displayAlerts, setDisplayAlerts] = useState<boolean>(true)
-  const { domain: attentiveDomain, promptForDomain, DomainPromptModal } = useAttentiveDomain()
-  const { showPrompt: showScreenPrompt, PromptModal: ScreenPromptModal } = useTextPrompt()
+  const {
+    domain: attentiveDomain,
+    promptForDomain,
+    DomainPromptModal,
+  } = useAttentiveDomain()
+  const { showPrompt: showScreenPrompt, PromptModal: ScreenPromptModal } =
+    useTextPrompt()
   const { identifyUser, clearUserIdentification } = useAttentiveUser()
-  const { triggerAttentiveCreative, recordCustomAttentiveEvent } = useAttentiveActions()
+  const { triggerAttentiveCreative, recordCustomAttentiveEvent } =
+    useAttentiveActions()
   const handleSubSuccess = useCallback(
     (message: string) => Alert.alert('Success', message),
     []
@@ -151,23 +168,29 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
    * Handle debugger toggle change
    * @param value - New debugger enabled state
    */
-  const handleDebuggerToggle = useCallback(async (value: boolean) => {
-    try {
-      setDebuggerEnabled(value)
-      await AsyncStorage.setItem(CONFIG_STORAGE_KEYS.DEBUGGER_ENABLED, value.toString())
-      if (displayAlerts) {
-        Alert.alert(
-          'Debugger Setting',
-          'Debugger setting has been saved. Note: This setting requires app restart to take effect.'
+  const handleDebuggerToggle = useCallback(
+    async (value: boolean) => {
+      try {
+        setDebuggerEnabled(value)
+        await AsyncStorage.setItem(
+          CONFIG_STORAGE_KEYS.DEBUGGER_ENABLED,
+          value.toString()
         )
+        if (displayAlerts) {
+          Alert.alert(
+            'Debugger Setting',
+            'Debugger setting has been saved. Note: This setting requires app restart to take effect.'
+          )
+        }
+      } catch (error) {
+        console.error('Error saving debugger setting:', error)
+        if (displayAlerts) {
+          Alert.alert('Error', 'Failed to save debugger setting')
+        }
       }
-    } catch (error) {
-      console.error('Error saving debugger setting:', error)
-      if (displayAlerts) {
-        Alert.alert('Error', 'Failed to save debugger setting')
-      }
-    }
-  }, [displayAlerts])
+    },
+    [displayAlerts]
+  )
 
   /**
    * Handle display alerts toggle change
@@ -176,7 +199,10 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
   const handleDisplayAlertsToggle = useCallback(async (value: boolean) => {
     try {
       setDisplayAlerts(value)
-      await AsyncStorage.setItem(CONFIG_STORAGE_KEYS.DISPLAY_ALERTS, value.toString())
+      await AsyncStorage.setItem(
+        CONFIG_STORAGE_KEYS.DISPLAY_ALERTS,
+        value.toString()
+      )
     } catch (error) {
       console.error('Error saving display alerts setting:', error)
       // Don't show alert here since alerts are being disabled
@@ -230,7 +256,10 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
       })
     } else {
       if (displayAlerts) {
-        Alert.alert('Note', 'Push permissions are handled automatically on Android')
+        Alert.alert(
+          'Note',
+          'Push permissions are handled automatically on Android'
+        )
       }
     }
   }, [displayAlerts])
@@ -240,7 +269,10 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
       const token = await AsyncStorage.getItem('deviceToken')
       if (!token) {
         if (displayAlerts) {
-          Alert.alert('Error', "No device token found. Press 'Show Push Permission' button to obtain one.")
+          Alert.alert(
+            'Error',
+            "No device token found. Press 'Show Push Permission' button to obtain one."
+          )
         }
         return
       }
@@ -249,7 +281,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = () => {
       if (Platform.OS === 'ios') {
         PushNotificationIOS.checkPermissions((permissions) => {
           // Determine authorization status based on permissions
-          let authStatus: 'authorized' | 'denied' | 'notDetermined' = 'notDetermined'
+          let authStatus: 'authorized' | 'denied' | 'notDetermined' =
+            'notDetermined'
           if (permissions.alert || permissions.badge || permissions.sound) {
             authStatus = 'authorized'
           }
@@ -322,7 +355,10 @@ The SDK will handle the API request internally.`
       PushNotificationIOS.scheduleLocalNotification(notification)
     } else {
       if (displayAlerts) {
-        Alert.alert('Note', 'Local push notifications require additional setup on Android')
+        Alert.alert(
+          'Note',
+          'Local push notifications require additional setup on Android'
+        )
       }
     }
   }, [displayAlerts])
@@ -356,7 +392,10 @@ The SDK will handle the API request internally.`
   const handleClearCookies = useCallback(async () => {
     // TODO: Implement WebKit cookie clearing via native bridge
     // For now, just show confirmation
-    Alert.alert('Success', 'Cookies cleared (WebKit cookies require native implementation)')
+    Alert.alert(
+      'Success',
+      'Cookies cleared (WebKit cookies require native implementation)'
+    )
   }, [])
 
   const handleCopyDeviceToken = useCallback(async () => {
@@ -404,16 +443,19 @@ The SDK will handle the API request internally.`
       <ScrollView style={styles.container}>
         {/* Account Info Section */}
         <View style={styles.section}>
-          <Text style={styles.accountInfoLabel}>
-            Login Info: {currentUser}
-          </Text>
+          <Text style={styles.accountInfoLabel}>Login Info: {currentUser}</Text>
 
           <Pressable
-            style={({ pressed }) => [getPrimaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getPrimaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleSwitchUser}
           >
             {({ pressed }) => (
-              <Text style={getPrimaryButtonTextStyle(pressed)}>Switch User</Text>
+              <Text style={getPrimaryButtonTextStyle(pressed)}>
+                Switch User
+              </Text>
             )}
           </Pressable>
 
@@ -487,7 +529,10 @@ The SDK will handle the API request internally.`
           ) : null}
 
           <Pressable
-            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getSecondaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleLogOut}
           >
             {({ pressed }) => (
@@ -496,11 +541,16 @@ The SDK will handle the API request internally.`
           </Pressable>
 
           <Pressable
-            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getSecondaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleManageAddresses}
           >
             {({ pressed }) => (
-              <Text style={getSecondaryButtonTextStyle(pressed)}>Manage Addresses</Text>
+              <Text style={getSecondaryButtonTextStyle(pressed)}>
+                Manage Addresses
+              </Text>
             )}
           </Pressable>
         </View>
@@ -512,74 +562,114 @@ The SDK will handle the API request internally.`
           <Text style={styles.sectionTitle}>Test Events & SDK Operations</Text>
 
           <Pressable
-            style={({ pressed }) => [getPrimaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getPrimaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleShowCreative}
           >
             {({ pressed }) => (
-              <Text style={getPrimaryButtonTextStyle(pressed)}>Show Creative</Text>
+              <Text style={getPrimaryButtonTextStyle(pressed)}>
+                Show Creative
+              </Text>
             )}
           </Pressable>
 
           <Pressable
-            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getSecondaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleShowPushPermission}
           >
             {({ pressed }) => (
-              <Text style={getSecondaryButtonTextStyle(pressed)}>Show Push Permission</Text>
+              <Text style={getSecondaryButtonTextStyle(pressed)}>
+                Show Push Permission
+              </Text>
             )}
           </Pressable>
 
           <Pressable
-            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getSecondaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleSendPushToken}
           >
             {({ pressed }) => (
-              <Text style={getSecondaryButtonTextStyle(pressed)}>Send Push Token</Text>
+              <Text style={getSecondaryButtonTextStyle(pressed)}>
+                Send Push Token
+              </Text>
             )}
           </Pressable>
 
           <Pressable
-            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getSecondaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleSendAppOpenEvents}
           >
             {({ pressed }) => (
-              <Text style={getSecondaryButtonTextStyle(pressed)}>📲 Send App Open Events</Text>
+              <Text style={getSecondaryButtonTextStyle(pressed)}>
+                📲 Send App Open Events
+              </Text>
             )}
           </Pressable>
 
           <Pressable
-            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getSecondaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleSendLocalPushNotification}
           >
             {({ pressed }) => (
-              <Text style={getSecondaryButtonTextStyle(pressed)}>🔔 Send Local Push Notification</Text>
+              <Text style={getSecondaryButtonTextStyle(pressed)}>
+                🔔 Send Local Push Notification
+              </Text>
             )}
           </Pressable>
 
           <Pressable
-            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getSecondaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleIdentifyUser}
           >
             {({ pressed }) => (
-              <Text style={getSecondaryButtonTextStyle(pressed)}>Identify User</Text>
+              <Text style={getSecondaryButtonTextStyle(pressed)}>
+                Identify User
+              </Text>
             )}
           </Pressable>
 
           <Pressable
-            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getSecondaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleClearUser}
           >
             {({ pressed }) => (
-              <Text style={getSecondaryButtonTextStyle(pressed)}>Clear User</Text>
+              <Text style={getSecondaryButtonTextStyle(pressed)}>
+                Clear User
+              </Text>
             )}
           </Pressable>
 
           <Pressable
-            style={({ pressed }) => [getSecondaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getSecondaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleClearCookies}
           >
             {({ pressed }) => (
-              <Text style={getSecondaryButtonTextStyle(pressed)}>Clear Cookies</Text>
+              <Text style={getSecondaryButtonTextStyle(pressed)}>
+                Clear Cookies
+              </Text>
             )}
           </Pressable>
         </View>
@@ -595,11 +685,16 @@ The SDK will handle the API request internally.`
           </Text>
 
           <Pressable
-            style={({ pressed }) => [getPrimaryButtonStyle(pressed), styles.buttonSpacing]}
+            style={({ pressed }) => [
+              getPrimaryButtonStyle(pressed),
+              styles.buttonSpacing,
+            ]}
             onPress={handleCopyDeviceToken}
           >
             {({ pressed }) => (
-              <Text style={getPrimaryButtonTextStyle(pressed)}>Copy Device Token</Text>
+              <Text style={getPrimaryButtonTextStyle(pressed)}>
+                Copy Device Token
+              </Text>
             )}
           </Pressable>
         </View>
@@ -637,9 +732,16 @@ The SDK will handle the API request internally.`
               >
                 {({ pressed }) =>
                   isOptingInEmail ? (
-                    <ActivityIndicator size="small" color={Colors.primaryText} />
+                    <ActivityIndicator
+                      size="small"
+                      color={Colors.primaryText}
+                    />
                   ) : (
-                    <Text style={getSecondaryButtonTextStyle(pressed && !isSubLoading)}>
+                    <Text
+                      style={getSecondaryButtonTextStyle(
+                        pressed && !isSubLoading
+                      )}
+                    >
                       OPT IN
                     </Text>
                   )
@@ -662,7 +764,9 @@ The SDK will handle the API request internally.`
                     <Text
                       style={[
                         styles.destructiveButtonText,
-                        pressed && !isSubLoading && styles.destructiveButtonTextPressed,
+                        pressed &&
+                          !isSubLoading &&
+                          styles.destructiveButtonTextPressed,
                       ]}
                     >
                       OPT OUT
@@ -699,9 +803,16 @@ The SDK will handle the API request internally.`
               >
                 {({ pressed }) =>
                   isOptingInPhone ? (
-                    <ActivityIndicator size="small" color={Colors.primaryText} />
+                    <ActivityIndicator
+                      size="small"
+                      color={Colors.primaryText}
+                    />
                   ) : (
-                    <Text style={getSecondaryButtonTextStyle(pressed && !isSubLoading)}>
+                    <Text
+                      style={getSecondaryButtonTextStyle(
+                        pressed && !isSubLoading
+                      )}
+                    >
                       OPT IN
                     </Text>
                   )
@@ -724,7 +835,9 @@ The SDK will handle the API request internally.`
                     <Text
                       style={[
                         styles.destructiveButtonText,
-                        pressed && !isSubLoading && styles.destructiveButtonTextPressed,
+                        pressed &&
+                          !isSubLoading &&
+                          styles.destructiveButtonTextPressed,
                       ]}
                     >
                       OPT OUT
@@ -756,7 +869,9 @@ The SDK will handle the API request internally.`
               onPress={handleAddEmail}
             >
               {({ pressed }) => (
-                <Text style={getPrimaryButtonTextStyle(pressed)}>Add Email</Text>
+                <Text style={getPrimaryButtonTextStyle(pressed)}>
+                  Add Email
+                </Text>
               )}
             </Pressable>
           </View>
@@ -774,7 +889,9 @@ The SDK will handle the API request internally.`
               onPress={handleAddPhone}
             >
               {({ pressed }) => (
-                <Text style={getPrimaryButtonTextStyle(pressed)}>Add Phone</Text>
+                <Text style={getPrimaryButtonTextStyle(pressed)}>
+                  Add Phone
+                </Text>
               )}
             </Pressable>
           </View>
@@ -866,7 +983,6 @@ The SDK will handle the API request internally.`
       {/* Cross-platform text prompt modals (null on iOS) */}
       {DomainPromptModal}
       {ScreenPromptModal}
-
     </>
   )
 }

--- a/Bonni/src/types/navigation.ts
+++ b/Bonni/src/types/navigation.ts
@@ -6,21 +6,42 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { Product } from '../models/Product'
 
 export type RootStackParamList = {
-  Login: undefined;
-  CreateAccount: undefined;
-  ProductList: undefined;
-  ProductDetail: { product: Product };
-  Cart: undefined;
-  Checkout: undefined;
-  OrderConfirmation: { orderId: string };
-  Settings: undefined;
-};
+  Login: undefined
+  CreateAccount: undefined
+  ProductList: undefined
+  ProductDetail: { product: Product }
+  Cart: undefined
+  Checkout: undefined
+  OrderConfirmation: { orderId: string }
+  Settings: undefined
+}
 
-export type LoginScreenProps = NativeStackScreenProps<RootStackParamList, 'Login'>;
-export type CreateAccountScreenProps = NativeStackScreenProps<RootStackParamList, 'CreateAccount'>;
-export type ProductListScreenProps = NativeStackScreenProps<RootStackParamList, 'ProductList'>;
-export type ProductDetailScreenProps = NativeStackScreenProps<RootStackParamList, 'ProductDetail'>;
-export type CartScreenProps = NativeStackScreenProps<RootStackParamList, 'Cart'>;
-export type CheckoutScreenProps = NativeStackScreenProps<RootStackParamList, 'Checkout'>;
-export type OrderConfirmationScreenProps = NativeStackScreenProps<RootStackParamList, 'OrderConfirmation'>;
-export type SettingsScreenProps = NativeStackScreenProps<RootStackParamList, 'Settings'>;
+export type LoginScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'Login'
+>
+export type CreateAccountScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'CreateAccount'
+>
+export type ProductListScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'ProductList'
+>
+export type ProductDetailScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'ProductDetail'
+>
+export type CartScreenProps = NativeStackScreenProps<RootStackParamList, 'Cart'>
+export type CheckoutScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'Checkout'
+>
+export type OrderConfirmationScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'OrderConfirmation'
+>
+export type SettingsScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'Settings'
+>

--- a/Bonni/src/utils/AttentivePushHelper.ts
+++ b/Bonni/src/utils/AttentivePushHelper.ts
@@ -17,14 +17,16 @@
  */
 
 import { Platform, AppState } from 'react-native'
-import PushNotificationIOS, { PushNotification } from '@react-native-community/push-notification-ios'
+import PushNotificationIOS, {
+  PushNotification,
+} from '@react-native-community/push-notification-ios'
 import {
-    registerDeviceTokenWithCallback,
-    registerForPushNotifications,
-    handleRegularOpen,
-    handleForegroundPush,
-    handlePushOpen,
-    type PushAuthorizationStatus,
+  registerDeviceTokenWithCallback,
+  registerForPushNotifications,
+  handleRegularOpen,
+  handleForegroundPush,
+  handlePushOpen,
+  type PushAuthorizationStatus,
 } from '../../../src'
 
 /**
@@ -32,379 +34,447 @@ import {
  * Implements the same logic as the native Swift callback-based approach
  */
 export class AttentivePushHelper {
-    private static instance: AttentivePushHelper
-    private deviceToken: string | null = null
-    private isRegistered: boolean = false
-    private appStateSubscription: any = null
+  private static instance: AttentivePushHelper
+  private deviceToken: string | null = null
+  private isRegistered: boolean = false
+  private appStateSubscription: any = null
 
-    private constructor() {}
+  private constructor() {}
 
-    /**
-     * Get the singleton instance
-     * @returns The singleton AttentivePushHelper instance
-     */
-    public static getInstance(): AttentivePushHelper {
-        if (!AttentivePushHelper.instance) {
-            AttentivePushHelper.instance = new AttentivePushHelper()
+  /**
+   * Get the singleton instance
+   * @returns The singleton AttentivePushHelper instance
+   */
+  public static getInstance(): AttentivePushHelper {
+    if (!AttentivePushHelper.instance) {
+      AttentivePushHelper.instance = new AttentivePushHelper()
+    }
+    return AttentivePushHelper.instance
+  }
+
+  /**
+   * Initialize push notifications with Attentive SDK
+   * This mirrors the Swift AppDelegate implementation
+   *
+   * @example
+   * ```typescript
+   * await attentivePush.initialize();
+   * ```
+   */
+  public async initialize(): Promise<void> {
+    console.log(
+      '🚀 [AttentivePush] STEP 1: Initializing push notification system',
+      { platform: Platform.OS }
+    )
+
+    if (Platform.OS !== 'ios') {
+      console.log(
+        '[AttentivePush] Android push notifications not yet implemented'
+      )
+      return
+    }
+
+    try {
+      // Set up event listeners
+      console.log('📝 [AttentivePush] STEP 2: Setting up event listeners')
+      this.setupEventListeners()
+
+      // Set up app state listener for app open tracking
+      console.log(
+        '📝 [AttentivePush] STEP 3: Setting up app state listener for app open tracking'
+      )
+      this.setupAppStateListener()
+
+      // Call handleRegularOpen immediately (before requesting permissions)
+      // This matches native iOS behavior where handleRegularOpen is called regardless of permission status
+      // Call synchronously with 'notDetermined' to ensure it happens before permission dialog
+      console.log(
+        '🔐 [AttentivePush] STEP 4: Calling handleRegularOpen on initialization'
+      )
+      console.log(
+        '   Initial authorization status: notDetermined (before permission request)'
+      )
+      console.log(
+        '🌉 [AttentivePush] Calling native: handleRegularOpen() (hits /mtctrl endpoint)'
+      )
+      handleRegularOpen('notDetermined')
+      console.log('✅ [AttentivePush] Initial handleRegularOpen completed')
+
+      // Request push notification permissions
+      console.log(
+        '🔐 [AttentivePush] STEP 5: Requesting push notification permissions'
+      )
+      await this.requestPermissions()
+
+      console.log('✅ [AttentivePush] Initialization complete')
+    } catch (error) {
+      console.error('❌ [AttentivePush] Initialization failed:', error)
+    }
+  }
+
+  /**
+   * Request push notification permissions
+   * Equivalent to calling registerForPushNotifications() in Swift
+   */
+  private async requestPermissions(): Promise<void> {
+    console.log(
+      '🌉 [AttentivePush] Calling native: registerForPushNotifications()'
+    )
+    registerForPushNotifications()
+  }
+
+  /**
+   * Setup app state listener to track app opens
+   *
+   * When the app comes to the foreground (becomes active), we call handleRegularOpen
+   * to track the app open event. This is important for analytics and engagement tracking.
+   *
+   * Note: Since handleAppDidBecomeActive() is private in the Attentive SDK,
+   * we use handleRegularOpen() instead, which serves the same purpose of tracking
+   * when the app becomes active.
+   */
+  private setupAppStateListener(): void {
+    console.log(
+      '📱 [AttentivePush] Setting up AppState listener for app open tracking'
+    )
+
+    this.appStateSubscription = AppState.addEventListener(
+      'change',
+      async (nextAppState) => {
+        console.log('[AttentivePush] AppState changed to:', nextAppState)
+
+        // When app becomes active (comes to foreground), track as app open
+        if (nextAppState === 'active') {
+          console.log(
+            '[AttentivePush] App became active - tracking app open event'
+          )
+
+          // Get current authorization status
+          const authStatus = await this.getAuthorizationStatus()
+          console.log('[AttentivePush] Authorization status:', authStatus)
+
+          // Track app open by calling handleRegularOpen
+          console.log(
+            '🌉 [AttentivePush] Calling native: handleRegularOpen() for app open tracking'
+          )
+          handleRegularOpen(authStatus)
+          console.log('✅ [AttentivePush] App open event tracked')
         }
-        return AttentivePushHelper.instance
-    }
+      }
+    )
+  }
 
-    /**
-     * Initialize push notifications with Attentive SDK
-     * This mirrors the Swift AppDelegate implementation
-     *
-     * @example
-     * ```typescript
-     * await attentivePush.initialize();
-     * ```
-     */
-    public async initialize(): Promise<void> {
-        console.log('🚀 [AttentivePush] STEP 1: Initializing push notification system', { platform: Platform.OS })
+  /**
+   * Setup event listeners for push notifications
+   * Mirrors the AppDelegate delegate methods
+   */
+  private setupEventListeners(): void {
+    // Handle device token registration
+    // Equivalent to: didRegisterForRemoteNotificationsWithDeviceToken
+    PushNotificationIOS.addEventListener('register', (deviceToken: string) => {
+      this.handleDeviceTokenRegistration(deviceToken)
+    })
 
-        if (Platform.OS !== 'ios') {
-            console.log('[AttentivePush] Android push notifications not yet implemented')
-            return
-        }
+    // Handle registration errors
+    // Equivalent to: didFailToRegisterForRemoteNotificationsWithError
+    PushNotificationIOS.addEventListener('registrationError', (error) => {
+      this.handleRegistrationError(error)
+    })
 
-        try {
-            // Set up event listeners
-            console.log('📝 [AttentivePush] STEP 2: Setting up event listeners')
-            this.setupEventListeners()
+    // Handle foreground notifications
+    // Equivalent to: willPresent notification
+    PushNotificationIOS.addEventListener(
+      'notification',
+      (notification: PushNotification) => {
+        this.handleForegroundNotification(notification)
+      }
+    )
 
-            // Set up app state listener for app open tracking
-            console.log('📝 [AttentivePush] STEP 3: Setting up app state listener for app open tracking')
-            this.setupAppStateListener()
+    // Handle notification tap
+    // Equivalent to: didReceive response
+    PushNotificationIOS.addEventListener(
+      'localNotification',
+      (notification: PushNotification) => {
+        this.handleNotificationTap(notification)
+      }
+    )
+  }
 
-            // Call handleRegularOpen immediately (before requesting permissions)
-            // This matches native iOS behavior where handleRegularOpen is called regardless of permission status
-            // Call synchronously with 'notDetermined' to ensure it happens before permission dialog
-            console.log('🔐 [AttentivePush] STEP 4: Calling handleRegularOpen on initialization')
-            console.log('   Initial authorization status: notDetermined (before permission request)')
-            console.log('🌉 [AttentivePush] Calling native: handleRegularOpen() (hits /mtctrl endpoint)')
-            handleRegularOpen('notDetermined')
-            console.log('✅ [AttentivePush] Initial handleRegularOpen completed')
+  /**
+   * Handle device token registration with callback-based logic
+   * Implements the same flow as the Swift callback-based method:
+   * 1. Get authorization status
+   * 2. Register device token with callback
+   * 3. In callback: Trigger regular open event
+   *
+   * This is the TypeScript equivalent of:
+   * ```swift
+   * func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+   *     UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+   *         guard let self = self else { return }
+   *         let authStatus = settings.authorizationStatus
+   *         attentiveSdk?.registerDeviceToken(deviceToken, authorizationStatus: authStatus, callback: { data, url, response, error in
+   *             DispatchQueue.main.async {
+   *                 self.attentiveSdk?.handleRegularOpen(authorizationStatus: authStatus)
+   *             }
+   *         })
+   *     }
+   * }
+   * ```
+   *
+   * @param deviceToken - The device token from APNs
+   */
+  private async handleDeviceTokenRegistration(
+    deviceToken: string
+  ): Promise<void> {
+    console.log('🎫 [AttentivePush] STEP 4: Device token received from APNs')
+    console.log('   Token (preview):', deviceToken.substring(0, 16) + '...')
+    console.log('   Token (full):', deviceToken)
+    console.log('   Token length:', deviceToken.length)
 
-            // Request push notification permissions
-            console.log('🔐 [AttentivePush] STEP 5: Requesting push notification permissions')
-            await this.requestPermissions()
+    this.deviceToken = deviceToken
 
-            console.log('✅ [AttentivePush] Initialization complete')
-        } catch (error) {
-            console.error('❌ [AttentivePush] Initialization failed:', error)
-        }
-    }
+    try {
+      // Get current authorization status (equivalent to getNotificationSettings)
+      const authStatus = await this.getAuthorizationStatus()
+      console.log(
+        '✅ [AttentivePush] STEP 5: Authorization status:',
+        authStatus
+      )
 
-    /**
-     * Request push notification permissions
-     * Equivalent to calling registerForPushNotifications() in Swift
-     */
-    private async requestPermissions(): Promise<void> {
-        console.log('🌉 [AttentivePush] Calling native: registerForPushNotifications()')
-        registerForPushNotifications()
-    }
+      // Register device token with Attentive SDK using callback-based method
+      console.log(
+        '📤 [AttentivePush] STEP 6: Registering device token with Attentive SDK (with callback)'
+      )
+      console.log('   Token:', deviceToken.substring(0, 16) + '...')
+      console.log('   Auth Status:', authStatus)
+      console.log(
+        '🌉 [AttentivePush] Calling native: registerDeviceTokenWithCallback()'
+      )
 
-    /**
-     * Setup app state listener to track app opens
-     *
-     * When the app comes to the foreground (becomes active), we call handleRegularOpen
-     * to track the app open event. This is important for analytics and engagement tracking.
-     *
-     * Note: Since handleAppDidBecomeActive() is private in the Attentive SDK,
-     * we use handleRegularOpen() instead, which serves the same purpose of tracking
-     * when the app becomes active.
-     */
-    private setupAppStateListener(): void {
-        console.log('📱 [AttentivePush] Setting up AppState listener for app open tracking')
+      // This is the equivalent of the Swift callback-based registration
+      registerDeviceTokenWithCallback(
+        deviceToken,
+        authStatus,
+        (data?: Object, url?: string, response?: Object, error?: Object) => {
+          console.log('📥 [AttentivePush] Registration callback invoked')
 
-        this.appStateSubscription = AppState.addEventListener('change', async (nextAppState) => {
-            console.log('[AttentivePush] AppState changed to:', nextAppState)
-
-            // When app becomes active (comes to foreground), track as app open
-            if (nextAppState === 'active') {
-                console.log('[AttentivePush] App became active - tracking app open event')
-
-                // Get current authorization status
-                const authStatus = await this.getAuthorizationStatus()
-                console.log('[AttentivePush] Authorization status:', authStatus)
-
-                // Track app open by calling handleRegularOpen
-                console.log('🌉 [AttentivePush] Calling native: handleRegularOpen() for app open tracking')
-                handleRegularOpen(authStatus)
-                console.log('✅ [AttentivePush] App open event tracked')
-            }
-        })
-    }
-
-    /**
-     * Setup event listeners for push notifications
-     * Mirrors the AppDelegate delegate methods
-     */
-    private setupEventListeners(): void {
-        // Handle device token registration
-        // Equivalent to: didRegisterForRemoteNotificationsWithDeviceToken
-        PushNotificationIOS.addEventListener('register', (deviceToken: string) => {
-            this.handleDeviceTokenRegistration(deviceToken)
-        })
-
-        // Handle registration errors
-        // Equivalent to: didFailToRegisterForRemoteNotificationsWithError
-        PushNotificationIOS.addEventListener('registrationError', (error) => {
-            this.handleRegistrationError(error)
-        })
-
-        // Handle foreground notifications
-        // Equivalent to: willPresent notification
-        PushNotificationIOS.addEventListener('notification', (notification: PushNotification) => {
-            this.handleForegroundNotification(notification)
-        })
-
-        // Handle notification tap
-        // Equivalent to: didReceive response
-        PushNotificationIOS.addEventListener('localNotification', (notification: PushNotification) => {
-            this.handleNotificationTap(notification)
-        })
-    }
-
-    /**
-     * Handle device token registration with callback-based logic
-     * Implements the same flow as the Swift callback-based method:
-     * 1. Get authorization status
-     * 2. Register device token with callback
-     * 3. In callback: Trigger regular open event
-     *
-     * This is the TypeScript equivalent of:
-     * ```swift
-     * func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-     *     UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
-     *         guard let self = self else { return }
-     *         let authStatus = settings.authorizationStatus
-     *         attentiveSdk?.registerDeviceToken(deviceToken, authorizationStatus: authStatus, callback: { data, url, response, error in
-     *             DispatchQueue.main.async {
-     *                 self.attentiveSdk?.handleRegularOpen(authorizationStatus: authStatus)
-     *             }
-     *         })
-     *     }
-     * }
-     * ```
-     *
-     * @param deviceToken - The device token from APNs
-     */
-    private async handleDeviceTokenRegistration(deviceToken: string): Promise<void> {
-        console.log('🎫 [AttentivePush] STEP 4: Device token received from APNs')
-        console.log('   Token (preview):', deviceToken.substring(0, 16) + '...')
-        console.log('   Token (full):', deviceToken)
-        console.log('   Token length:', deviceToken.length)
-
-        this.deviceToken = deviceToken
-
-        try {
-            // Get current authorization status (equivalent to getNotificationSettings)
-            const authStatus = await this.getAuthorizationStatus()
-            console.log('✅ [AttentivePush] STEP 5: Authorization status:', authStatus)
-
-            // Register device token with Attentive SDK using callback-based method
-            console.log('📤 [AttentivePush] STEP 6: Registering device token with Attentive SDK (with callback)')
-            console.log('   Token:', deviceToken.substring(0, 16) + '...')
-            console.log('   Auth Status:', authStatus)
-            console.log('🌉 [AttentivePush] Calling native: registerDeviceTokenWithCallback()')
-
-            // This is the equivalent of the Swift callback-based registration
-            registerDeviceTokenWithCallback(
-                deviceToken,
-                authStatus,
-                (data?: Object, url?: string, response?: Object, error?: Object) => {
-                    console.log('📥 [AttentivePush] Registration callback invoked')
-
-                    if (error) {
-                        console.error('❌ [AttentivePush] Registration callback returned error:', error)
-                    } else {
-                        console.log('✅ [AttentivePush] STEP 7: Device token registered successfully')
-                        console.log('   Response URL:', url)
-                        console.log('   Response:', response)
-                        console.log('   Data:', data)
-                    }
-
-                    // Mark as registered (even if there was an error, we attempted registration)
-                    this.isRegistered = true
-
-                    // Trigger regular open event (equivalent to DispatchQueue.main.async { handleRegularOpen })
-                    console.log('📱 [AttentivePush] STEP 8: Triggering regular open event from callback')
-                    console.log('🌉 [AttentivePush] Calling native: handleRegularOpen()')
-                    handleRegularOpen(authStatus)
-                    console.log('✅ [AttentivePush] Regular open event triggered successfully')
-                }
+          if (error) {
+            console.error(
+              '❌ [AttentivePush] Registration callback returned error:',
+              error
             )
+          } else {
+            console.log(
+              '✅ [AttentivePush] STEP 7: Device token registered successfully'
+            )
+            console.log('   Response URL:', url)
+            console.log('   Response:', response)
+            console.log('   Data:', data)
+          }
 
-        } catch (error) {
-            console.error('❌ [AttentivePush] Device token registration failed:', error)
-            console.error('   Error details:', JSON.stringify(error, null, 2))
+          // Mark as registered (even if there was an error, we attempted registration)
+          this.isRegistered = true
 
-            // Even on failure, trigger regular open event
-            const authStatus = await this.getAuthorizationStatus()
-            console.log('📱 [AttentivePush] Triggering regular open event after error')
-            handleRegularOpen(authStatus)
+          // Trigger regular open event (equivalent to DispatchQueue.main.async { handleRegularOpen })
+          console.log(
+            '📱 [AttentivePush] STEP 8: Triggering regular open event from callback'
+          )
+          console.log('🌉 [AttentivePush] Calling native: handleRegularOpen()')
+          handleRegularOpen(authStatus)
+          console.log(
+            '✅ [AttentivePush] Regular open event triggered successfully'
+          )
         }
+      )
+    } catch (error) {
+      console.error(
+        '❌ [AttentivePush] Device token registration failed:',
+        error
+      )
+      console.error('   Error details:', JSON.stringify(error, null, 2))
+
+      // Even on failure, trigger regular open event
+      const authStatus = await this.getAuthorizationStatus()
+      console.log(
+        '📱 [AttentivePush] Triggering regular open event after error'
+      )
+      handleRegularOpen(authStatus)
     }
+  }
 
-    /**
-     * Handle registration errors
-     * Equivalent to: didFailToRegisterForRemoteNotificationsWithError
-     *
-     * @param error - The registration error
-     */
-    private async handleRegistrationError(error: any): Promise<void> {
-        console.error('❌ [AttentivePush] Failed to register for remote notifications')
-        console.error('   Error:', error)
-        console.error('   Error details:', JSON.stringify(error, null, 2))
+  /**
+   * Handle registration errors
+   * Equivalent to: didFailToRegisterForRemoteNotificationsWithError
+   *
+   * @param error - The registration error
+   */
+  private async handleRegistrationError(error: any): Promise<void> {
+    console.error(
+      '❌ [AttentivePush] Failed to register for remote notifications'
+    )
+    console.error('   Error:', error)
+    console.error('   Error details:', JSON.stringify(error, null, 2))
 
-        // Even on failure, trigger regular open event
-        const authStatus = await this.getAuthorizationStatus()
-        console.log('📱 [AttentivePush] Triggering regular open event after registration error')
-        console.log('🌉 [AttentivePush] Calling native: handleRegularOpen()')
-        handleRegularOpen(authStatus)
-    }
+    // Even on failure, trigger regular open event
+    const authStatus = await this.getAuthorizationStatus()
+    console.log(
+      '📱 [AttentivePush] Triggering regular open event after registration error'
+    )
+    console.log('🌉 [AttentivePush] Calling native: handleRegularOpen()')
+    handleRegularOpen(authStatus)
+  }
 
-    /**
-     * Get current authorization status
-     * @returns Promise that resolves to the authorization status
-     */
-    private async getAuthorizationStatus(): Promise<PushAuthorizationStatus> {
-        return new Promise((resolve) => {
-            PushNotificationIOS.checkPermissions((permissions) => {
-                if (permissions.alert || permissions.badge || permissions.sound) {
-                    resolve('authorized')
-                } else if (permissions.authorizationStatus === 0) {
-                    resolve('notDetermined')
-                } else {
-                    resolve('denied')
-                }
-            })
-        })
-    }
+  /**
+   * Get current authorization status
+   * @returns Promise that resolves to the authorization status
+   */
+  private async getAuthorizationStatus(): Promise<PushAuthorizationStatus> {
+    return new Promise((resolve) => {
+      PushNotificationIOS.checkPermissions((permissions) => {
+        if (permissions.alert || permissions.badge || permissions.sound) {
+          resolve('authorized')
+        } else if (permissions.authorizationStatus === 0) {
+          resolve('notDetermined')
+        } else {
+          resolve('denied')
+        }
+      })
+    })
+  }
 
-    /**
-     * Handle foreground notification
-     * Equivalent to: willPresent notification
-     *
-     * This now uses the new handleForegroundPush method for better tracking.
-     *
-     * @param notification - The notification object
-     */
-    private async handleForegroundNotification(notification: PushNotification): Promise<void> {
-        const userInfo = notification.getData()
-        console.log('📬 [AttentivePush] Notification received in foreground')
-        console.log('   User info:', JSON.stringify(userInfo, null, 2))
+  /**
+   * Handle foreground notification
+   * Equivalent to: willPresent notification
+   *
+   * This now uses the new handleForegroundPush method for better tracking.
+   *
+   * @param notification - The notification object
+   */
+  private async handleForegroundNotification(
+    notification: PushNotification
+  ): Promise<void> {
+    const userInfo = notification.getData()
+    console.log('📬 [AttentivePush] Notification received in foreground')
+    console.log('   User info:', JSON.stringify(userInfo, null, 2))
 
-        // Get authorization status
-        const authStatus = await this.getAuthorizationStatus()
+    // Get authorization status
+    const authStatus = await this.getAuthorizationStatus()
 
-        // Use handleForegroundPush for better tracking (matches native iOS pattern)
-        console.log('🌉 [AttentivePush] Calling native: handleForegroundPush()')
+    // Use handleForegroundPush for better tracking (matches native iOS pattern)
+    console.log('🌉 [AttentivePush] Calling native: handleForegroundPush()')
+    handleForegroundPush(userInfo, authStatus)
+
+    // Complete the notification
+    notification.finish(PushNotificationIOS.FetchResult.NoData)
+  }
+
+  /**
+   * Handle notification tap
+   * Equivalent to: didReceive response
+   *
+   * This is the TypeScript equivalent of the native iOS AppDelegate method:
+   * ```swift
+   * func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+   *     UNUserNotificationCenter.current().getNotificationSettings { settings in
+   *       let authStatus = settings.authorizationStatus
+   *       DispatchQueue.main.async {
+   *         switch UIApplication.shared.applicationState {
+   *         case .active:
+   *           self.attentiveSdk?.handleForegroundPush(response: response, authorizationStatus: authStatus)
+   *         case .background, .inactive:
+   *           self.attentiveSdk?.handlePushOpen(response: response, authorizationStatus: authStatus)
+   *         @unknown default:
+   *           self.attentiveSdk?.handlePushOpen(response: response, authorizationStatus: authStatus)
+   *         }
+   *       }
+   *     }
+   *     completionHandler()
+   *   }
+   * ```
+   *
+   * @param notification - The notification object
+   */
+  private async handleNotificationTap(
+    notification: PushNotification
+  ): Promise<void> {
+    const userInfo = notification.getData()
+    console.log('👆 [AttentivePush] Notification tapped by user')
+    console.log('   User info:', JSON.stringify(userInfo, null, 2))
+
+    // Get current app state (equivalent to UIApplication.shared.applicationState)
+    const appState = AppState.currentState
+    console.log('   App state:', appState)
+
+    // Get authorization status (equivalent to getNotificationSettings)
+    const authStatus = await this.getAuthorizationStatus()
+    console.log('   Authorization status:', authStatus)
+
+    // Determine which SDK method to call based on app state
+    // This matches the native iOS switch statement exactly
+    switch (appState) {
+      case 'active':
+        // App is in foreground - handle as foreground push
+        console.log(
+          '🌉 [AttentivePush] App state: active - calling handleForegroundPush()'
+        )
         handleForegroundPush(userInfo, authStatus)
+        break
 
-        // Complete the notification
-        notification.finish(PushNotificationIOS.FetchResult.NoData)
+      case 'background':
+      case 'inactive':
+        // App is in background or inactive - handle as push open
+        console.log(
+          '🌉 [AttentivePush] App state: background/inactive - calling handlePushOpen()'
+        )
+        handlePushOpen(userInfo, authStatus)
+        break
+
+      default:
+        // Unknown state - default to push open behavior (matches @unknown default in Swift)
+        console.log(
+          '🌉 [AttentivePush] App state: unknown - calling handlePushOpen()'
+        )
+        handlePushOpen(userInfo, authStatus)
+        break
     }
 
-    /**
-     * Handle notification tap
-     * Equivalent to: didReceive response
-     *
-     * This is the TypeScript equivalent of the native iOS AppDelegate method:
-     * ```swift
-     * func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-     *     UNUserNotificationCenter.current().getNotificationSettings { settings in
-     *       let authStatus = settings.authorizationStatus
-     *       DispatchQueue.main.async {
-     *         switch UIApplication.shared.applicationState {
-     *         case .active:
-     *           self.attentiveSdk?.handleForegroundPush(response: response, authorizationStatus: authStatus)
-     *         case .background, .inactive:
-     *           self.attentiveSdk?.handlePushOpen(response: response, authorizationStatus: authStatus)
-     *         @unknown default:
-     *           self.attentiveSdk?.handlePushOpen(response: response, authorizationStatus: authStatus)
-     *         }
-     *       }
-     *     }
-     *     completionHandler()
-     *   }
-     * ```
-     *
-     * @param notification - The notification object
-     */
-    private async handleNotificationTap(notification: PushNotification): Promise<void> {
-        const userInfo = notification.getData()
-        console.log('👆 [AttentivePush] Notification tapped by user')
-        console.log('   User info:', JSON.stringify(userInfo, null, 2))
+    // Complete the notification
+    notification.finish(PushNotificationIOS.FetchResult.NoData)
+  }
 
-        // Get current app state (equivalent to UIApplication.shared.applicationState)
-        const appState = AppState.currentState
-        console.log('   App state:', appState)
+  /**
+   * Check if push notifications are registered
+   * @returns true if device token has been registered
+   */
+  public isDeviceRegistered(): boolean {
+    return this.isRegistered
+  }
 
-        // Get authorization status (equivalent to getNotificationSettings)
-        const authStatus = await this.getAuthorizationStatus()
-        console.log('   Authorization status:', authStatus)
+  /**
+   * Get the current device token
+   * @returns The device token or null if not registered
+   */
+  public getDeviceToken(): string | null {
+    return this.deviceToken
+  }
 
-        // Determine which SDK method to call based on app state
-        // This matches the native iOS switch statement exactly
-        switch (appState) {
-            case 'active':
-                // App is in foreground - handle as foreground push
-                console.log('🌉 [AttentivePush] App state: active - calling handleForegroundPush()')
-                handleForegroundPush(userInfo, authStatus)
-                break
+  /**
+   * Cleanup event listeners
+   * Call this when your component unmounts
+   */
+  public cleanup(): void {
+    PushNotificationIOS.removeEventListener('register')
+    PushNotificationIOS.removeEventListener('registrationError')
+    PushNotificationIOS.removeEventListener('notification')
+    PushNotificationIOS.removeEventListener('localNotification')
 
-            case 'background':
-            case 'inactive':
-                // App is in background or inactive - handle as push open
-                console.log('🌉 [AttentivePush] App state: background/inactive - calling handlePushOpen()')
-                handlePushOpen(userInfo, authStatus)
-                break
-
-            default:
-                // Unknown state - default to push open behavior (matches @unknown default in Swift)
-                console.log('🌉 [AttentivePush] App state: unknown - calling handlePushOpen()')
-                handlePushOpen(userInfo, authStatus)
-                break
-        }
-
-        // Complete the notification
-        notification.finish(PushNotificationIOS.FetchResult.NoData)
+    // Cleanup app state listener
+    if (this.appStateSubscription) {
+      this.appStateSubscription.remove()
+      this.appStateSubscription = null
     }
-
-    /**
-     * Check if push notifications are registered
-     * @returns true if device token has been registered
-     */
-    public isDeviceRegistered(): boolean {
-        return this.isRegistered
-    }
-
-    /**
-     * Get the current device token
-     * @returns The device token or null if not registered
-     */
-    public getDeviceToken(): string | null {
-        return this.deviceToken
-    }
-
-    /**
-     * Cleanup event listeners
-     * Call this when your component unmounts
-     */
-    public cleanup(): void {
-        PushNotificationIOS.removeEventListener('register')
-        PushNotificationIOS.removeEventListener('registrationError')
-        PushNotificationIOS.removeEventListener('notification')
-        PushNotificationIOS.removeEventListener('localNotification')
-
-        // Cleanup app state listener
-        if (this.appStateSubscription) {
-            this.appStateSubscription.remove()
-            this.appStateSubscription = null
-        }
-    }
+  }
 }
 
 /**

--- a/Bonni/src/utils/pushDebugHelpers.ts
+++ b/Bonni/src/utils/pushDebugHelpers.ts
@@ -1,6 +1,6 @@
 /**
  * Simple debugging helpers for push notification troubleshooting
- * 
+ *
  * These utilities help you quickly check push notification state
  * during debugging sessions.
  */
@@ -12,177 +12,186 @@ import { Platform } from 'react-native'
  * Get detailed push notification permission status
  */
 export async function checkPushPermissions(): Promise<void> {
-    if (Platform.OS !== 'ios') {
-        console.log('❌ Push permissions check only available on iOS')
-        return
-    }
+  if (Platform.OS !== 'ios') {
+    console.log('❌ Push permissions check only available on iOS')
+    return
+  }
 
-    return new Promise((resolve) => {
-        PushNotificationIOS.checkPermissions((permissions) => {
-            console.log('📋 Push Notification Permissions:')
-            console.log('   Alert:', permissions.alert ? '✅' : '❌')
-            console.log('   Badge:', permissions.badge ? '✅' : '❌')
-            console.log('   Sound:', permissions.sound ? '✅' : '❌')
-            console.log('   Lock Screen:', permissions.lockScreen ? '✅' : '❌')
-            console.log('   Notification Center:', permissions.notificationCenter ? '✅' : '❌')
-            console.log('   Critical Alert:', permissions.critical ? '✅' : '❌')
-            console.log('   Authorization Status:', permissions.authorizationStatus)
-            
-            resolve()
-        })
+  return new Promise((resolve) => {
+    PushNotificationIOS.checkPermissions((permissions) => {
+      console.log('📋 Push Notification Permissions:')
+      console.log('   Alert:', permissions.alert ? '✅' : '❌')
+      console.log('   Badge:', permissions.badge ? '✅' : '❌')
+      console.log('   Sound:', permissions.sound ? '✅' : '❌')
+      console.log('   Lock Screen:', permissions.lockScreen ? '✅' : '❌')
+      console.log(
+        '   Notification Center:',
+        permissions.notificationCenter ? '✅' : '❌'
+      )
+      console.log('   Critical Alert:', permissions.critical ? '✅' : '❌')
+      console.log('   Authorization Status:', permissions.authorizationStatus)
+
+      resolve()
     })
+  })
 }
 
 /**
  * Request push permissions and log the result
  */
 export async function requestPushPermissions(): Promise<void> {
-    if (Platform.OS !== 'ios') {
-        console.log('❌ Push permissions request only available on iOS')
-        return
-    }
+  if (Platform.OS !== 'ios') {
+    console.log('❌ Push permissions request only available on iOS')
+    return
+  }
 
-    console.log('🔐 Requesting push notification permissions...')
-    
-    return new Promise((resolve) => {
-        PushNotificationIOS.requestPermissions({
-            alert: true,
-            badge: true,
-            sound: true,
-        }).then((permissions) => {
-            console.log('✅ Permissions requested')
-            console.log('   Result:', JSON.stringify(permissions, null, 2))
-            resolve()
-        }).catch((error) => {
-            console.error('❌ Failed to request permissions:', error)
-            resolve()
-        })
+  console.log('🔐 Requesting push notification permissions...')
+
+  return new Promise((resolve) => {
+    PushNotificationIOS.requestPermissions({
+      alert: true,
+      badge: true,
+      sound: true,
     })
+      .then((permissions) => {
+        console.log('✅ Permissions requested')
+        console.log('   Result:', JSON.stringify(permissions, null, 2))
+        resolve()
+      })
+      .catch((error) => {
+        console.error('❌ Failed to request permissions:', error)
+        resolve()
+      })
+  })
 }
 
 /**
  * Log current device token if available
  */
 export function logDeviceToken(): void {
-    console.log('🎫 Checking for device token...')
-    console.log('   Note: Token is received asynchronously via "register" event')
-    console.log('   Make sure you have a listener set up for PushNotificationIOS.addEventListener("register", ...)')
+  console.log('🎫 Checking for device token...')
+  console.log('   Note: Token is received asynchronously via "register" event')
+  console.log(
+    '   Make sure you have a listener set up for PushNotificationIOS.addEventListener("register", ...)'
+  )
 }
 
 /**
  * Print a summary of push notification setup
  */
 export async function printPushSetupSummary(): Promise<void> {
-    console.log('\n' + '='.repeat(60))
-    console.log('📱 PUSH NOTIFICATION SETUP SUMMARY')
-    console.log('='.repeat(60))
-    
-    console.log('\n1️⃣ Platform:', Platform.OS)
-    
-    if (Platform.OS === 'ios') {
-        console.log('\n2️⃣ Permissions:')
-        await checkPushPermissions()
-        
-        console.log('\n3️⃣ Device Token:')
-        logDeviceToken()
-    } else {
-        console.log('\n❌ Push notifications only supported on iOS in this implementation')
-    }
-    
-    console.log('\n' + '='.repeat(60) + '\n')
+  console.log('\n' + '='.repeat(60))
+  console.log('📱 PUSH NOTIFICATION SETUP SUMMARY')
+  console.log('='.repeat(60))
+
+  console.log('\n1️⃣ Platform:', Platform.OS)
+
+  if (Platform.OS === 'ios') {
+    console.log('\n2️⃣ Permissions:')
+    await checkPushPermissions()
+
+    console.log('\n3️⃣ Device Token:')
+    logDeviceToken()
+  } else {
+    console.log(
+      '\n❌ Push notifications only supported on iOS in this implementation'
+    )
+  }
+
+  console.log('\n' + '='.repeat(60) + '\n')
 }
 
 /**
  * Simulate a test notification (for debugging UI)
  */
 export function simulateTestNotification(): void {
-    if (Platform.OS !== 'ios') {
-        console.log('❌ Test notification only available on iOS')
-        return
-    }
+  if (Platform.OS !== 'ios') {
+    console.log('❌ Test notification only available on iOS')
+    return
+  }
 
-    console.log('🧪 Simulating local test notification...')
-    
-    PushNotificationIOS.addNotificationRequest({
-        id: 'test-notification-' + Date.now(),
-        title: 'Test Notification',
-        body: 'This is a test notification from the debug helper',
-        badge: 1,
-        sound: 'default',
-        userInfo: {
-            test: true,
-            timestamp: new Date().toISOString(),
-        },
-    })
-    
-    console.log('✅ Local notification scheduled')
+  console.log('🧪 Simulating local test notification...')
+
+  PushNotificationIOS.addNotificationRequest({
+    id: 'test-notification-' + Date.now(),
+    title: 'Test Notification',
+    body: 'This is a test notification from the debug helper',
+    badge: 1,
+    sound: 'default',
+    userInfo: {
+      test: true,
+      timestamp: new Date().toISOString(),
+    },
+  })
+
+  console.log('✅ Local notification scheduled')
 }
 
 /**
  * Clear all delivered notifications
  */
 export function clearAllNotifications(): void {
-    if (Platform.OS !== 'ios') {
-        console.log('❌ Clear notifications only available on iOS')
-        return
-    }
+  if (Platform.OS !== 'ios') {
+    console.log('❌ Clear notifications only available on iOS')
+    return
+  }
 
-    console.log('🧹 Clearing all delivered notifications...')
-    PushNotificationIOS.removeAllDeliveredNotifications()
-    console.log('✅ Notifications cleared')
+  console.log('🧹 Clearing all delivered notifications...')
+  PushNotificationIOS.removeAllDeliveredNotifications()
+  console.log('✅ Notifications cleared')
 }
 
 /**
  * Get count of delivered notifications
  */
 export function getDeliveredNotificationCount(): Promise<number> {
-    if (Platform.OS !== 'ios') {
-        console.log('❌ Notification count only available on iOS')
-        return Promise.resolve(0)
-    }
+  if (Platform.OS !== 'ios') {
+    console.log('❌ Notification count only available on iOS')
+    return Promise.resolve(0)
+  }
 
-    return new Promise((resolve) => {
-        PushNotificationIOS.getDeliveredNotifications((notifications) => {
-            const count = notifications.length
-            console.log('📬 Delivered notifications:', count)
-            if (count > 0) {
-                console.log('   Notifications:', JSON.stringify(notifications, null, 2))
-            }
-            resolve(count)
-        })
+  return new Promise((resolve) => {
+    PushNotificationIOS.getDeliveredNotifications((notifications) => {
+      const count = notifications.length
+      console.log('📬 Delivered notifications:', count)
+      if (count > 0) {
+        console.log('   Notifications:', JSON.stringify(notifications, null, 2))
+      }
+      resolve(count)
     })
+  })
 }
 
 /**
  * Complete debugging session - print all relevant info
  */
 export async function debugPushNotifications(): Promise<void> {
-    console.log('\n' + '🐛'.repeat(30))
-    console.log('STARTING PUSH NOTIFICATION DEBUG SESSION')
-    console.log('🐛'.repeat(30) + '\n')
-    
-    await printPushSetupSummary()
-    
-    console.log('📊 Additional Info:')
-    await getDeliveredNotificationCount()
-    
-    console.log('\n💡 Tips:')
-    console.log('   - Use checkPushPermissions() to verify permissions')
-    console.log('   - Use simulateTestNotification() to test notification UI')
-    console.log('   - Use clearAllNotifications() to clear notification center')
-    console.log('   - Check Xcode console for native APNs logs')
-    
-    console.log('\n' + '🐛'.repeat(30) + '\n')
+  console.log('\n' + '🐛'.repeat(30))
+  console.log('STARTING PUSH NOTIFICATION DEBUG SESSION')
+  console.log('🐛'.repeat(30) + '\n')
+
+  await printPushSetupSummary()
+
+  console.log('📊 Additional Info:')
+  await getDeliveredNotificationCount()
+
+  console.log('\n💡 Tips:')
+  console.log('   - Use checkPushPermissions() to verify permissions')
+  console.log('   - Use simulateTestNotification() to test notification UI')
+  console.log('   - Use clearAllNotifications() to clear notification center')
+  console.log('   - Check Xcode console for native APNs logs')
+
+  console.log('\n' + '🐛'.repeat(30) + '\n')
 }
 
 // Export all functions as a namespace for easy access
 export const PushDebug = {
-    checkPermissions: checkPushPermissions,
-    requestPermissions: requestPushPermissions,
-    logToken: logDeviceToken,
-    summary: printPushSetupSummary,
-    simulate: simulateTestNotification,
-    clear: clearAllNotifications,
-    count: getDeliveredNotificationCount,
-    debug: debugPushNotifications,
+  checkPermissions: checkPushPermissions,
+  requestPermissions: requestPushPermissions,
+  logToken: logDeviceToken,
+  summary: printPushSetupSummary,
+  simulate: simulateTestNotification,
+  clear: clearAllNotifications,
+  count: getDeliveredNotificationCount,
+  debug: debugPushNotifications,
 }


### PR DESCRIPTION
## Problem

Bonni's ESLint preset (`@react-native@0.77`) ships **`eslint-config-prettier`** (which turns off ESLint's own formatting rules) but **not** `eslint-plugin-prettier`. So `npm run lint` never checked formatting at all — formatting that diverged from `Bonni/.prettierrc.js` passed lint, pre-commit, and CI. (This surfaced in PR #92, where a hand-written test file was committed with non-conformant brace spacing yet linted clean.)

The SDK (repo root) doesn't have this gap: its `eslintConfig` uses `@react-native-community` + `prettier/prettier: ["error", …]`, so `lint-sdk` already enforces formatting.

## Change (Option A — match the SDK's mechanism)

- **`.eslintrc.js`** → `extends: ['@react-native', 'plugin:prettier/recommended']`, which turns on `prettier/prettier` as an **error**. Dropped the now-redundant `semi` rule (Prettier owns semicolons).
- **`.prettierrc.js`** → made to match the SDK's root config (`quoteProps: consistent`, `singleQuote`, `tabWidth: 2`, `trailingComma: es5`, `useTabs: false`, `semi: false`). Both packages now enforce the **same style**.
- **`package.json`** → added `eslint-plugin-prettier` + `eslint-config-prettier` devDeps (matching the SDK's ranges).
- **Reformatted the Bonni tree** (`prettier --write`) to the shared style — the bulk of the diff.

No `lefthook.yml` change: the existing **`lint-bonni`** pre-commit hook and the **CI ESLint step** (`.circleci/config.yml:187`) now enforce formatting automatically. No standalone `prettier --check` needed.

**Fix path for contributors:** `npx eslint . --fix` (or editor ESLint) auto-fixes formatting, same as the SDK.

## Verification

- `npx eslint .` (Bonni) → **0 errors**; a deliberately mis-formatted file now fails with `error … prettier/prettier`.
- `tsc --noEmit` → clean.
- `npx jest` → **34/34** pass (no behavior change — formatting only, plus the ESLint config/deps).
- Pre-commit hook exercised on this commit: `lint-bonni` ✔️ / `types-bonni` ✔️.

## Notes

- Formatting-only reformat; no runtime/behavior changes.
- Built on top of merged `main` (PR #92 fix + PR #93 lefthook), so no overlap conflicts.

MSDK-427

🤖 Generated with [Claude Code](https://claude.com/claude-code)
