### PR TITLE
fix(ci): honor operator-provided release notes in the SDK release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,10 @@ jobs:
           command: npm ci
       - run:
           name: Release SDK (release-it + npm Trusted Publishing)
+          environment:
+            # Operator-supplied notes passed via env (not interpolated into the script)
+            # so arbitrary note text can never be interpreted as shell.
+            RELEASE_NOTES: << pipeline.parameters.release_notes >>
           command: |
             set -euo pipefail
             VERSION="<< pipeline.parameters.release_version >>"
@@ -279,7 +283,16 @@ jobs:
             if [ "${IS_PRERELEASE}" = "true" ]; then
               RELEASE_ARGS="${RELEASE_ARGS} --github.preRelease --npm.tag=beta"
             fi
-            npx release-it ${RELEASE_ARGS}
+
+            # Use the operator-supplied notes for the GitHub Release when provided;
+            # otherwise fall back to the @release-it/conventional-changelog notes.
+            # The notes go through a file + `cat` so arbitrary text is never run as shell.
+            if [ -n "${RELEASE_NOTES:-}" ]; then
+              printf '%s' "${RELEASE_NOTES}" > /tmp/release_notes.txt
+              npx release-it ${RELEASE_ARGS} --github.releaseNotes="cat /tmp/release_notes.txt"
+            else
+              npx release-it ${RELEASE_ARGS}
+            fi
       - run:
           name: Open version-bump PR to main
           # NON-FATAL by design: release-it has already published to npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,6 +287,10 @@ jobs:
             # Use the operator-supplied notes for the GitHub Release when provided;
             # otherwise fall back to the @release-it/conventional-changelog notes.
             # The notes go through a file + `cat` so arbitrary text is never run as shell.
+            # CircleCI renders an EMPTY pipeline parameter passed via `environment:` as the
+            # literal string "<nil>" (documented), not "" — normalize it back to empty so the
+            # no-notes path falls back to the changelog instead of publishing "<nil>".
+            [ "${RELEASE_NOTES:-}" = "<nil>" ] && RELEASE_NOTES=""
             if [ -n "${RELEASE_NOTES:-}" ]; then
               printf '%s' "${RELEASE_NOTES}" > /tmp/release_notes.txt
               npx release-it ${RELEASE_ARGS} --github.releaseNotes="cat /tmp/release_notes.txt"


### PR DESCRIPTION
## What

The `release_notes` pipeline parameter is declared in `.circleci/config.yml` and is **always** sent by the "Release SDK" GitHub Actions workflow — but the `release` job never threaded it into `release-it`. So operator-typed release notes were **silently dropped**, and every GitHub Release used the auto-generated conventional-changelog notes.

This wires it through, with a fallback:

- Pass `release_notes` to the job as an **env var** (`environment: RELEASE_NOTES`) rather than interpolating it into the shell script — so arbitrary note text can never be interpreted as shell.
- When `RELEASE_NOTES` is non-empty → hand it to `release-it` via `--github.releaseNotes`, reading from a file (`printf … > /tmp/release_notes.txt` + `cat`), so quotes/`$`/backticks in the notes stay literal.
- When empty → omit the flag → `release-it` falls back to the `@release-it/conventional-changelog` notes (**current behavior, unchanged**).

## Why via a file + `cat`

`release-it`'s `github.releaseNotes` runs its value as a command and uses the stdout as the release body. Passing the notes as a file that `cat` prints keeps operator text out of the command string entirely (no injection, no quoting hell).

## Public API impact

None. CI-only change to the `release` job; no JS/TS API, no native module/bridge, no `Bonni`/host-app change. The empty-notes path is byte-for-byte the current behavior.

## Verification

- `YAML` validated (Psych `safe_load`, aliases allowed).
- Shell branching tested both ways, including a note string with `$HOME`, backticks and quotes — preserved **verbatim** in the file (no expansion/injection); empty input takes the fallback branch with no `--github.releaseNotes`.
- Behavior confirmed against the installed **release-it 15.9.3** source, `lib/plugin/GitRelease.js:25-30` / `:34-38`: a set `releaseNotes` is executed as a command and its output becomes the release body; unset → the changelog.
- First real end-to-end exercise will be the next release; the **beta path is the safe way to validate** (it skips PR-to-main and TestFlight).

## Rollback

Revert the single commit; the `release` job returns to always using conventional-changelog notes. No state to unwind.
