### PR TITLE
chore: add .prettierignore to exclude Markdown

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Prettier is only used for TypeScript here (via eslint-plugin-prettier over
+# src/ and plugin/src/); Markdown is not part of the lint or CI toolchain.
+# Excluding it stops editor format-on-save from reformatting docs — and from
+# mangling GitHub-flavored constructs like `> [!WARNING]` alerts (Prettier 2.x).
+*.md


### PR DESCRIPTION
## Summary

Adds a `.prettierignore` that excludes Markdown from Prettier.

## Why

Prettier is only wired up for **TypeScript** in this repo (via `eslint-plugin-prettier`, scoped to `src/` and `plugin/src/`). Nothing in `lint` or CI formats or checks Markdown. But with no ignore file, an editor with *format-on-save* runs Prettier over `.md` files too — and Prettier 2.x (`^2.0.5`, our pinned version) mangles GitHub-flavored Markdown:

- collapses `> [!WARNING]` / `> [!NOTE]` alert blocks onto one line, which **breaks their rendering on GitHub**
- garbles bold/italic runs like `**_ … _**`
- reformats fenced code blocks and pads tables, producing large noisy diffs on unrelated doc edits

This surfaced while editing `README.md`/`AGENTS.md`: saving reformatted the whole file and broke the warning callout. Excluding Markdown makes the tooling match reality (docs were never part of the Prettier scope) and stops format-on-save from corrupting them.

## Scope

- One new file, `.prettierignore`, containing `*.md` with an explanatory comment.
- No code, no CI, no dependency changes. Does not affect TypeScript formatting (that runs through `eslint-plugin-prettier` over the TS globs, unchanged).

## Verification

- `npx prettier --check "**/*.md"` reports "All matched files use Prettier code style!" only because the files are now ignored (before: reformatting diffs). TypeScript formatting via `npm run lint` is unaffected.
- No runtime surface; nothing to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)